### PR TITLE
Pass on the HTML chapter

### DIFF
--- a/.github/workflows/compare.yml
+++ b/.github/workflows/compare.yml
@@ -14,3 +14,4 @@ jobs:
       - run: python3 compare.py book/http.md src/lab1.py
       - run: python3 compare.py book/graphics.md src/lab2.py
       - run: python3 compare.py book/text.md src/lab3.py
+      - run: python3 compare.py book/html.md src/lab4.py

--- a/book/html.md
+++ b/book/html.md
@@ -5,11 +5,6 @@ prev: text
 next: layout
 ...
 
-::: {.todo}
-- HTML attributes are unmotivated
-- I've dropped `<meta>` and `<link>` self-closing tags, probably should put them back somehow
-:::
-
 So far, your web browser sees web pages as a stream of open tags,
 close tags, and text. But HTML is actually a tree, and though the tree
 structure hasn't been important yet, you'll need it to draw
@@ -448,6 +443,10 @@ a slow but a sure process.
 
 HTML attributes
 ===============
+
+::: {.todo}
+- HTML attributes are unmotivated
+:::
 
 HTML tags have tag names but also *attributes*, which are added to an
 open tag to give additional information about that element. For example,

--- a/book/html.md
+++ b/book/html.md
@@ -233,7 +233,8 @@ def __init__(self, text):
 ```
 
 This code assumes all attributes have a value, but in fact the value
-can be omitted! If no value is given, it defaults to the empty string:
+can be omitted, like in `<input disabled>`. In this case, the
+attribute value is supposed to default to the empty string:
 
 ``` {.python indent=8}
 for attrpair in parts[1:]:

--- a/book/html.md
+++ b/book/html.md
@@ -21,6 +21,17 @@ for both open and close tags. But HTML is a tree, and each open and
 close tag pair are one node in the tree, as is each text token. We
 need to convert from tokens to nodes.
 
+We'll need a new `parse` function to do that:
+
+``` {.python}
+if __name__ == "__main__":
+    # ...
+    nodes = parse(lex(body))
+    browser = Browser()
+    browser.layout(nodes)
+    # ...
+```
+
 Let's start by defining the two types of nodes:[^1]
 
 [^1]: In reality there are other types of nodes too, like comments,

--- a/book/html.md
+++ b/book/html.md
@@ -157,10 +157,14 @@ This produces a more reasonable result:
  <link rel="stylesheet" href="../book.css" />]
 ```
 
-Why aren't these open elements closed? Well, most of them (like
+Why aren't these open elements closed?[^4] Well, most of them (like
 `<meta>` and `<link>`) are what are called self-closing: they don't
 need a close tag because they never surround content. Let's add a case
 for that to our parser:
+
+[^4]: Some people put a slash at the end of a self-closing tag (like
+    `<br/>`) but they don't have to: `<br>` is self-closing both with
+    and without that slash.
 
 ``` {.python indent=8}
 # ...
@@ -671,11 +675,3 @@ Exercises
 [^3]: Yes, it's a crazy system, and for a few years in the early '00s
     the W3C tried to [do away with it](https://www.w3.org/TR/xhtml1/).
     They failed.
-
-[^4]: Some people put a slash at the end of a self-closing tag (like
-    `<br/>`) but they don't have to: `<br>` is self-closing with and
-    without that slash.
-
-[^6]: If you implemented earlier exercises like support for `<a>`,
-    `<small>`, and `<big>`, you will likely have more parts to the
-    state.

--- a/book/html.md
+++ b/book/html.md
@@ -567,7 +567,15 @@ sibling paragraphs instead of one paragraph inside another.
 *Scripts:* JavaScript code embedded in a `<script>` tag uses the left
 angle bracket to mean less-than. Modify your lexer so that the
 contents of `<script>` tags are treated specially: no tags are allowed
-inside `<script>`, except the `</script>` close tag.
+inside `<script>`, except the `</script>` close tag.[^or-space]
+
+[^or-space]: Technically it's just `</script` followed by a [space,
+    tab, `\v`, `\r`, slash, or greater than sign][script-end-state].
+    If you need to talk about `</script>` tags inside your JavaScript
+    code, split it across multiple strings. I talk about it in a
+    video.
+
+[script-end-state]: https://html.spec.whatwg.org/multipage/parsing.html#script-data-end-tag-name-state
 
 *Quoted attributes:* Quoted attributes can contain spaces and right
 angle brackets. Fix the lexer so that this is supported properly.

--- a/book/html.md
+++ b/book/html.md
@@ -10,12 +10,11 @@ next: layout
 - I've dropped `<meta>` and `<link>` self-closing tags, probably should put them back somehow
 :::
 
-So far, our web browser understands web pages as a stream of HTML
-tokens: open tags, close tags, and text. It\'s worked for now, but
-that superficial view of HTML will hold us back when we try to draw
-backgrounds and borders, let alone implement CSS. HTML has a tree
-structure essential to those elements of style. So let\'s change our
-browser to parse HTML, and lay out the page, as a tree.
+So far, your web browser sees web pages as a stream of open tags,
+close tags, and text. But HTML is actually a tree, and though the tree
+structure hasn't been important yet, you'll need it to draw
+backgrounds, add margins, and let alone implement CSS. So this chapter
+adds a proper HTML parser and converts the layout engine to use it.
 
 
 A tree of nodes
@@ -24,13 +23,13 @@ A tree of nodes
 Right now, our browser understands web pages as a flat sequence of tags
 and text. HTML more structure than this: each open tag has a
 corresponding close tag, and the stuff between those two is
-\"contained\" within that tag. Every open tag must be closed before
+"contained" within that tag. Every open tag must be closed before
 closing its parent.
 
 So, the tags form a tree, and every pair of open and close tags forms a
 node of that tree. Of course, the tree also has to contain another kind
 of node: text. We call the two types of nodes *element nodes* and *text
-nodes*; there isn\'t additional structure besides those two.[^1] Here\'s
+nodes*; there isn't additional structure besides those two.[^1] Here's
 a data structure for these two types:[^2]
 
 ``` {.python}
@@ -47,7 +46,7 @@ class TextNode:
 ```
 
 We need to create these `Node` structures from the list of tokens. The
-overall idea is pretty simple. Keep track of the node that we\'re
+overall idea is pretty simple. Keep track of the node that we're
 currently in. When we see an open tag, create a new node and go into it;
 when we see a close tag, go back out to its parent. The current node
 will start out with a dummy value:
@@ -69,7 +68,7 @@ current.children.append(new)
 ```
 
 For `Tag` tokens, we check whether the tag starts with a slash to
-determine whether it\'s an open or a close tag. For open tags, we create
+determine whether it's an open or a close tag. For open tags, we create
 a new `ElementNode`, make it a child of the current node, and then make
 the new node current:
 
@@ -86,15 +85,15 @@ if current.parent is not None:
     current = current.parent
 ```
 
-Here I\'m testing `current.parent` because of a subtlety with the root
+Here I'm testing `current.parent` because of a subtlety with the root
 of the tree. The first thing in an HTML document is always the `<html>`
-open tag, so it\'s safe to start `current` with the dummy value `None`:
-it\'ll immediately be replaced by an `ElementNode`. But then when we
-reach the `</html>` close tag, we don\'t want to walk up to the parent,
+open tag, so it's safe to start `current` with the dummy value `None`:
+it'll immediately be replaced by an `ElementNode`. But then when we
+reach the `</html>` close tag, we don't want to walk up to the parent,
 which would cause `current` to take on that dummy `None` value again: if
-that happened, we wouldn\'t be able to get back to the nodes we just
+that happened, we wouldn't be able to get back to the nodes we just
 created! So instead I do nothing, so that moments later we exit the
-`for` loop and return the nodes we\'ve created.
+`for` loop and return the nodes we've created.
 
 
 Debugging your parser
@@ -144,7 +143,7 @@ return a tree anyway.[^3]
 
 For example, some HTML tags serve as both an open and a close tag (they
 are called self-closing tags). The `<br>` tag, which inserts a line
-break, is one such tag. However, right now, our parser doesn\'t know
+break, is one such tag. However, right now, our parser doesn't know
 that, and will just keep looking for a `</br>` tag that never
 arrives.[^4]
 
@@ -158,7 +157,7 @@ current = new
 ```
 
 Here, the first line creates the element and the second makes it a child
-of its parent. Then, the third one \"enters\" the new node, in effect
+of its parent. Then, the third one "enters" the new node, in effect
 opening it. For a self-closing tag, we just need to avoid doing that:
 
 ``` {.python}
@@ -170,13 +169,13 @@ Now is a good time, by the way, to implement `<br>` in `layout`; it
 works pretty much the same way that `<p>` does, ending the current line
 by resetting `x` and incrementing `y`.
 
-Self-closing tags aren\'t supposed to have close tags; but sometimes
+Self-closing tags aren't supposed to have close tags; but sometimes
 people forget close tags for elements that really should have them. For
 example, you might have a `<p>` inside a `<section>` and then close the
 `</section>` without closing the `</p>`. Because these errors are so
-common, browsers try to automatically fix them so they do the \"right
-thing\". The full algorithm is pretty complicated (there are multiple
-types of tags and so on) but let\'s implement a simple version of it:
+common, browsers try to automatically fix them so they do the "right
+thing". The full algorithm is pretty complicated (there are multiple
+types of tags and so on) but let's implement a simple version of it:
 when a close tag is encountered, we will walk up the tree until we find
 a tag that it closes.
 
@@ -189,9 +188,9 @@ while node is not None and node.tag != tagname:
 
 Here, we start by taking `tok.tag` and stripping off the initial slash.
 Then, we walk up the tree of nodes until we find a node with a matching
-tag. Once we\'re done with the loop, there are two cases: either we
+tag. Once we're done with the loop, there are two cases: either we
 found a matching node (in which case we set `current` to its parent) or
-we didn\'t (in which case we assume it\'s a typo and you meant to close
+we didn't (in which case we assume it's a typo and you meant to close
 the current tag).
 
 ``` {.python}
@@ -202,7 +201,7 @@ if current.parent is not None:
     current = current.parent
 ```
 
-There\'s also a chance that the page author forgot to close the tags
+There's also a chance that the page author forgot to close the tags
 they opened. In that case we want to implicitly close the remaining open
 tags. That takes a loop just before the return statement.
 
@@ -212,7 +211,7 @@ while current.parent:
 ```
 
 These rules for malformed HTML may seem arbitrary, and they are. But
-they evolved over years of trying to guess what people \"meant\" when
+they evolved over years of trying to guess what people "meant" when
 they wrote that HTML, and are now codified in the [HTML 5 parsing
 algorithm](https://www.w3.org/TR/2011/WD-html5-20110113/parsing.html),
 which spells out in detail how to handle user errors. The tweaks above
@@ -236,10 +235,10 @@ points to.[^5] Attributes look like this:
 You can have any number of attributes in an open tag; the names are
 case-insensitive, while the values are an arbitrary string of character
 that can even include spaces if you surround them with quotes. Also, the
-values are optional; \"`<tagname attrname>`\" is perfectly valid and
+values are optional; "`<tagname attrname>`" is perfectly valid and
 sets that attribute to an empty string.
 
-Let\'s extend `ElementNode` to store attributes:
+Let's extend `ElementNode` to store attributes:
 
 ``` {.python}
 class ElementNode:
@@ -302,11 +301,11 @@ def layout(node):
         layout_text(node)
 ```
 
-One complication is `layout`\'s local variables: the current `x` and `y`
+One complication is `layout`'s local variables: the current `x` and `y`
 position, the current `bold` and `italic` state, and even that tricky
 `terminal_space` variable that took up so much time in the last chapter.
-Plus, there\'s the `display_list` variable for render commands. To turn
-`layout` into a recursive function, we\'ll need those local variables to
+Plus, there's the `display_list` variable for render commands. To turn
+`layout` into a recursive function, we'll need those local variables to
 become global state that multiple invocations of `layout` can share:[^6]
 
 ``` {.python}
@@ -340,7 +339,7 @@ The new `layout_close` will be pretty similar (unsetting the flags),
 while `layout_text` will do the line wrapping and terminal space
 computations from the last chapter.
 
-Finally, don\'t forget to update `show` to get its display list from
+Finally, don't forget to update `show` to get its display list from
 inside `state`.
 
 ``` {.python}
@@ -353,10 +352,10 @@ Summary
 =======
 
 In this chapter, we taught our browser to understand HTML as a
-structured tree, not just a flat list of tokens, and we\'ve updated
+structured tree, not just a flat list of tokens, and we've updated
 layout to be a recursive tree traversal instead of a linear pass through
-the document. We\'ve also made the browser much more robust to malformed
-HTML. While these changes don\'t have much impact yet, this new,
+the document. We've also made the browser much more robust to malformed
+HTML. While these changes don't have much impact yet, this new,
 structured understanding of HTML sets us up to implement a layout
 engine in the next chapter.
 
@@ -364,48 +363,48 @@ engine in the next chapter.
 Exercises
 =========
 
--   HTML documents almost always start with \"doctype declarations\". These
-    look like tags that begin with `!doctype` and don\'t have close
+-   HTML documents almost always start with "doctype declarations". These
+    look like tags that begin with `!doctype` and don't have close
     tags. Doctype declarations, when they are present, are always the
     first token in a document. Skip doctype declarations in the parser.
 -   Update the HTML lexer and parser to support comments. Comments in
-    HTML begin with `<!--` and end with `-->`. However, comments aren\'t
+    HTML begin with `<!--` and end with `-->`. However, comments aren't
     the same as tags: they can contain any text, including open or close
     tags. Comments should be a new token type, which `parse` should
     ignore.
 -   Update the HTML lexer or parser to support *entities*. Entities in
     HTML begin an ampersand `&`, then contain letters and numbers, and
-    end with a semicolon \"`;`\"; they resolve to particular characters.
+    end with a semicolon "`;`"; they resolve to particular characters.
     Implement support for `&amp;`, `&lt;`, `&gt;`, and `&quot;`, which
     expand to ampersand, less than, greater than, and the quotation
     mark. Should you handle entities in the lexer, the parser, or in an
     earlier pass? Consider that attribute values can contain entities.
--   For some tags, it doesn\'t make sense to have one inside the other.
-    For example, it\'s not clear what it would mean for one paragraph to
+-   For some tags, it doesn't make sense to have one inside the other.
+    For example, it's not clear what it would mean for one paragraph to
     contain another, so the most common reason for this to happen in a
     web page is that someone forgot a close tag. Change the parser so
     that a document like `<p>hello<p>world</p>` results in two sibling
     nodes instead of one paragraph inside another.
--   The attribute parser doesn\'t correctly handle attribute values
+-   The attribute parser doesn't correctly handle attribute values
     that contain spaces, which is valid when the attribute is quoted.
     Fix this case in the attribute parser. You will likely need to
     loop over the attribute character-by-character.
 
-[^1]: To be clear: there is additional structure, we\'re just ignoring
+[^1]: To be clear: there is additional structure, we're just ignoring
     it for now.
 
-[^2]: Tracking the parent like I\'m doing here is going to be useful for
+[^2]: Tracking the parent like I'm doing here is going to be useful for
     parsing.
 
-[^3]: Yes, it\'s a crazy system, and for a few years in the early '00s
+[^3]: Yes, it's a crazy system, and for a few years in the early '00s
     the W3C tried to [do away with it](https://www.w3.org/TR/xhtml1/).
     They failed.
 
 [^4]: Some people put a slash at the end of a self-closing tag (like
-    `<br/>`) but they don\'t have to: `<br>` is self-closing with and
+    `<br/>`) but they don't have to: `<br>` is self-closing with and
     without that slash.
 
-[^5]: Where `href` stands for \"hypertext reference\".
+[^5]: Where `href` stands for "hypertext reference".
 
 [^6]: If you implemented earlier exercises like support for `<a>`,
     `<small>`, and `<big>`, you will likely have more parts to the

--- a/book/html.md
+++ b/book/html.md
@@ -121,7 +121,7 @@ doesn't return anything; let's find out why:
 def parse(tokens):
     # ...
     print(currently_open)
-    raise Exception("Reached end of token before end of document"))
+    raise Exception("Reached last token before end of document"))
 ```
 
 Python prints a list of `ElementNode` objects, meaning that there were
@@ -308,19 +308,19 @@ if isinstance(tok, Text):
 With this change, the parser can now parse this page, and most other
 valid HTML pages!
 
-Now our browser should *use* this element tree. Let's add a `layout`
-method to replace the current `for` loop inside the constructor. To
-start, we can just call `token` twice per element node, emulating the
-old token-based layout:
+Now our browser should *use* this element tree. Let's add a `recurse`
+method to replace the current `for` loop inside the `Layout`
+constructor. To start, we can just call `token` twice per element
+node, emulating the old token-based layout:
 
 ``` {.python indent=4 expected=False}
-def layout(self, tree):
+def recurse(self, tree):
     if isinstance(tree, TextNode):
         self.text(tree.text)
     else:
         self.token(Tag(tree.tag))
         for child in tree.children:
-            self.layout(child)
+            self.recurse(child)
         self.token(Tag("/" + tree.tag))
 ```
 
@@ -347,7 +347,7 @@ def close(self, tag):
     # ...
 ```
 
-Make sure to update `layout` to call these two new functions; now it
+Make sure to update `recurse` to call these two new functions; now it
 no longer has to construct `Tag` objects or add slashes to things to
 indicate a close tag!
 

--- a/book/html.md
+++ b/book/html.md
@@ -546,12 +546,6 @@ web pages, as we will see in the [next chapter](layout.md).
 Exercises
 =========
 
-*Entities:* Implement support for `&amp;`, `&lt;`, `&gt;`, and
-`&quot;`, which expand to ampersand, less than, greater than, and the
-quotation mark in HTML. These "entities" can go either in ordinary
-text or inside tags. Should you handle entities in the lexer or the
-parser?
-
 *Comments:* Update the HTML lexer to support comments. Comments in
 HTML begin with `<!--` and end with `-->`. However, comments aren't
 the same as tags: they can contain any text, including left and right
@@ -581,3 +575,10 @@ inside `<script>`, except the `</script>` close tag.[^or-space]
 angle brackets. Fix the lexer so that this is supported properly.
 Hint: the current lexer is a finite state machine, with two states
 (determined by `in_tag`). You'll need more states.
+
+*Syntax Highlighting:* Implement the `view-source:` protocol as in
+[Chapter 1](http.md#exercises), but make it syntax-highlight the
+source code of HTML pages. Keep source code for HTML tags in a normal
+font, but make text contents bold. If you've implemented it, wrap text
+in `<pre>` tags as well to preserve line breaks. Use your browser's
+HTML lexer to implement the syntax highlighter.

--- a/book/html.md
+++ b/book/html.md
@@ -449,7 +449,8 @@ if open_tags == [] and tag != "html":
 ```
 
 With the `<head>` and `<body>` elements, you need to look at the tag
-being handled. Some tags go in the `<head>` element:
+being handled. Only a few tags are actually supposed to go in the
+`<head>` element:
 
 ``` {.python}
 HEAD_TAGS = [
@@ -458,7 +459,13 @@ HEAD_TAGS = [
 ]
 ```
 
-That tells you whether to insert `<head>` or `<body>`:
+That tells you whether to insert `<head>` or `<body>`:[^where-script]
+
+[^where-script]: Note that some tags, like `<script>`, can go in
+    either the head or body section of an HTML document. The code
+    below places it inside a `<head>` tag by default, but doesn't
+    prevent its being explicitly placed inside `<body>` by the page
+    author.
 
 ``` {.python indent=8}
 elif open_tags == ["html"] and tag not in ["head", "body", "/html"]:
@@ -476,21 +483,23 @@ need to implicitly close the `<head>` section:
 elif open_tags == ["html", "head"] and tag not in ["/head"] + HEAD_TAGS:
     node = currently_open.pop()
     currently_open[-1].children.append(node)
-    currently_open.append(ElementNode("body"))
 ```
 
-In all other cases, implicit tags aren't needed, and we can exit the
-loop:
+Note that the this code doesn't create the `<body>` element itself.
+That's for the next iteration of the loop.
+
+The loop ends for all other cases, with no additional implicit tags
+being inserted:
 
 ``` {.python indent=8}
 else:
     break
 ```
 
-We haven't yet handled the implicit close tags `</body>` and
-`</html>`. Usually, leaving them out will mean the `parse` function
-reaches the end of its loop without closing all open tags, and would
-thus return nothing. Let's make it return *something* instead:
+We also want implicit close tags for `</body>` and `</html>`. Usually,
+leaving them out will mean the `parse` function reaches the end of its
+loop without closing all open tags, and would thus return nothing.
+Let's make it return *something* instead:
 
 ``` {.python}
 def parse(tokens):

--- a/book/html.md
+++ b/book/html.md
@@ -531,7 +531,7 @@ Summary
 This chapter taught our browser that HTML is a tree, not just a flat
 list of tokens. We added:
 
-- A parser now transforms HTML tokens to a tree
+- A parser to transform HTML tokens to a tree
 - Layout operating recursively on the tree
 - Code to recognize and handle attributes on elements
 - Automatic fixes for some malformed HTML documents

--- a/book/html.md
+++ b/book/html.md
@@ -8,8 +8,8 @@ next: layout
 So far, your web browser sees web pages as a stream of open tags,
 close tags, and text. But HTML is actually a tree, and though the tree
 structure hasn't been important yet, you'll need it to draw
-backgrounds, add margins, and let alone implement CSS. So this chapter
-adds a proper HTML parser and converts the layout engine to use it.
+backgrounds, add margins, and implement CSS. So this chapter adds a
+proper HTML parser and converts the layout engine to use it.
 
 
 A tree of nodes
@@ -207,16 +207,18 @@ totally ignored.
 Attributes
 ==========
 
-It doesn't help; why? Because the problem tags aren't just `<meta>`:
-they have attributes, like in `<meta charset="utf-8" />`. HTML
-attributes give additional information about an element; open tags can
-have any number of attributes (though close tags can't have any).
-Attribute values can be either quoted, unquoted, or omitted entirely.
+Strangely, the self-closing tag code in the previous section doesn't
+help; why? Because the problem tags aren't just `<meta>`: they have
+attributes, like in `<meta charset="utf-8" />`. HTML attributes give
+additional information about an element; open tags can have any number
+of attributes (though close tags can't have any). Attribute values can
+be either quoted, unquoted, or omitted entirely.
 
-For simplicity, let's stick to unquoted attribute values. Since
-neither tag names nor attribute-value pairs can contain
-whitespace,[^because-unquoted] we can split the tag contents on
-whitespace:
+Attribute values can be anything, and if they're quoted they can even
+contain whitespace. But for simplicity, let's stick to unquoted
+attribute values. Then neither tag names nor attribute-value pairs can
+contain whitespace, so we can split the tag contents on whitespace to
+get the tag name and the attribute-value pairs:
 
 ``` {.python}
 class Tag:
@@ -224,8 +226,6 @@ class Tag:
         parts = text.split()
         self.tag = parts[0].lower()
 ```
-
-[^because-unquoted]: Because only unquoted attribute values are supported!
 
 Note that the tag name is converted to lower case, because HTML tag
 names are case-insensitive.
@@ -296,7 +296,10 @@ This special tag is called a [doctype][html5-doctype], and it's not
 really an element at all. It's not supposed to have close tag, but we
 can't mark it a self-closing tag—it's always the very first thing in
 the document, so there wouldn't be an open element to append it to.
-It's best to throw it away:
+It's best to throw it away:[^quirks-mode]
+
+[^quirks-mode]: Real browsers also set some flags that switch between
+    standards-compliant and legacy parsing and layout modes.
 
 ``` {.python indent=8}
 elif tok.tag.startswith("!"):
@@ -504,7 +507,7 @@ wrote that HTML, and are now codified in the [HTML parsing
 standard](html5-parsing).
 
 ::: {.further}
-HTML parsers also have an [algorithm][adoption] to handle misnested
+HTML parsers also have an [algorithm][adoption] to handle mis-nested
 elements, plus a [list of active formatting
 elements][html5-formatting-list] to handle formatting like
 `<b>b<i>bi</b>i</i>`.
@@ -517,14 +520,14 @@ Summary
 =======
 
 This chapter taught our browser that HTML is a tree, not just a flat
-list of tokens:
+list of tokens. We added:
 
 - A parser now transforms HTML tokens to a tree
-- Layout operates recursively on the tree
-- The lexer recognizes and handles attributes on elements
-- Some malformed HTML documents are automatically fixed
+- Layout operating recursively on the tree
+- Code to recognize and handle attributes on elements
+- Automatic fixes for some malformed HTML documents
 
-The tree structure of HTML is essential to lay out visually complex
+The tree structure of HTML is essential to display visually complex
 web pages, as we will see in the [next chapter](layout.md).
 
 ::: {.signup}

--- a/book/html.md
+++ b/book/html.md
@@ -20,116 +20,308 @@ adds a proper HTML parser and converts the layout engine to use it.
 A tree of nodes
 ===============
 
-Right now, our browser understands web pages as a flat sequence of tags
-and text. HTML more structure than this: each open tag has a
-corresponding close tag, and the stuff between those two is
-"contained" within that tag. Every open tag must be closed before
-closing its parent.
+Right now, the browser sees web pages as a flat sequence of tags and
+text, which is why the `Layout` object's `token` method includes code
+for both open and close tags. But HTML is a tree, and each open and
+close tag pair are one node in the tree, as is each text token. We
+need to convert from tokens to nodes.
 
-So, the tags form a tree, and every pair of open and close tags forms a
-node of that tree. Of course, the tree also has to contain another kind
-of node: text. We call the two types of nodes *element nodes* and *text
-nodes*; there isn't additional structure besides those two.[^1] Here's
-a data structure for these two types:[^2]
+Let's start by defining the two types of nodes:[^1]
+
+[^1]: In reality there are other types of nodes too, like comments,
+    doctypes, and `CDATA` sections, and processing instructions. There
+    are even some deprecated types!
 
 ``` {.python}
 class ElementNode:
-    def __init__(self, parent, tagname):
-        self.tag = tagname
+    def __init__(self, tag):
+        self.tag = tag
         self.children = []
-        self.parent = parent
 
 class TextNode:
-    def __init__(self, parent, text):
+    def __init__(self, text):
         self.text = text
-        self.parent = parent
 ```
 
-We need to create these `Node` structures from the list of tokens. The
-overall idea is pretty simple. Keep track of the node that we're
-currently in. When we see an open tag, create a new node and go into it;
-when we see a close tag, go back out to its parent. The current node
-will start out with a dummy value:
+Element nodes start empty, and our parser fills them in. The idea is
+simple: keep track of the currently open elements, and any time we
+finish a node (at a text or end tag token) we add it to the
+bottom-most currently-open element. Let's store the currently open
+elements in a list, from top to bottom:
 
 ``` {.python}
-current = None
-for tok in tokens:
+def parse(tokens):
+    currently_open = []
+    for tok in tokens:
+        # ...
+```
+
+Inside the loop, we need to figure out if the token is text, an open
+tag, or a close tag, and do the appropriate thing. `Text` tokens are
+the easiest: create a new `TextNode` and add it to the bottom-most
+open element.
+
+``` {.python indent=8}
+if isinstance(tok, Text):
+    node = TextNode(tok.text)
+    currently_open[-1].children.append(node)
+```
+
+End tags are similar, but instead of making a new node they take the
+bottom-most open element:
+
+``` {.python indent=8 expected=True}
+elif tok.tag.startswith("/"):
+    node = currently_open.pop()
+    currently_open[-1].children.append(node)
+```
+
+Finally, for open tags, we need to create a new `ElementNode` and add
+it to the list of currently open elements:
+
+``` {.python indent=8}
+else:
+    node = ElementNode(tok.tag)
+    currently_open.append(node)
+```
+
+The core of this logic is about right, but what and when does the
+parser return? Try parsing
+
+``` {.html}
+<html><body><h1>Hi!</h1></body></html>
+```
+
+and the parser will read the `</html>` element, pop the last open
+element off the list of open elements, and then crash since there's no
+open element to append it to. So in this case we actually want to
+return that root element:
+
+``` {.python indent=8}
+elif tok.tag.startswith("/"):
+    node = currently_open.pop()
+    if not currently_open: return node
+    currently_open[-1].children.append(node)
+```
+
+Time to test this parser out!
+
+::: {.further}
+The real [HTML parsing algorithm][html5-after-body] doesn't stop when
+it sees the `</html>` tag; it just moves to a state called `after
+after body`, and any additional nodes are added to the end of the
+`<body>` element. It also doesn't require you to write the `<html>`
+tag to begin with.
+:::
+
+[html5-after-body]: https://html.spec.whatwg.org/multipage/parsing.html#parsing-main-afterbody
+
+Parsing subtleties
+==================
+
+Try running this parser on this page, and you'll find that `parse`
+doesn't return anything; let's find out why:
+
+``` {.python expected=False}
+def parse(tokens):
     # ...
-return current
+    print(currently_open)
+    raise Exception("Reached end of token before end of document"))
 ```
 
-In that look, we need to figure out if the token is text, an open tag,
-or a close tag, and do the appropriate thing. `Text` tokens are the
-easiest:
+Python prints a list of `ElementNode` objects, meaning that there were
+open HTML elements still around when it reached the last token. Why?
+Unfortunately, Python does not help us resolve the mystery, because it
+prints `ElementNode`s like this:
 
-``` {.python}
-new = TextNode(current, tok.text)
-current.children.append(new)
+```
+[<__main__.ElementNode object at 0x101399c70>,  ...]
 ```
 
-For `Tag` tokens, we check whether the tag starts with a slash to
-determine whether it's an open or a close tag. For open tags, we create
-a new `ElementNode`, make it a child of the current node, and then make
-the new node current:
+Python needs a method called `__repr__` to be defined to print things
+a little more reasonably:
 
 ``` {.python}
-new = ElementNode(current, tok.tag)
-if current is not None: current.children.append(new)
-current = new
+class ElementNode:
+    # ...
+    def __repr__(self):
+        return "<" + self.tag + ">"
 ```
 
-Finally, close tags exit from the current node to its parent:
+This produces a more reasonable result:
 
-``` {.python}
-if current.parent is not None:
-    current = current.parent
+``` 
+[<!DOCTYPE html>,
+ <html lang="en-US" xml:lang="en-US">,
+ <head>,
+ <meta charset="utf-8" />,
+ <meta name="generator" content="pandoc" />,
+ <meta name="viewport" content=... />,
+ <link rel="prev" href="text" />,
+ <link rel="next" href="layout" />,
+ <link rel="stylesheet" href="../book.css" />]
 ```
 
-Here I'm testing `current.parent` because of a subtlety with the root
-of the tree. The first thing in an HTML document is always the `<html>`
-open tag, so it's safe to start `current` with the dummy value `None`:
-it'll immediately be replaced by an `ElementNode`. But then when we
-reach the `</html>` close tag, we don't want to walk up to the parent,
-which would cause `current` to take on that dummy `None` value again: if
-that happened, we wouldn't be able to get back to the nodes we just
-created! So instead I do nothing, so that moments later we exit the
-`for` loop and return the nodes we've created.
+Why aren't these open elements closed? Well, most of them (like
+`<meta>` and `<link>`) are what are called self-closing: they don't
+need a close tag because they never surround content. Let's add a case
+for that to our parser:
 
+``` {.python indent=8}
+# ...
+elif tok.is_self_closing():
+    node = ElementNode(tok.tag)
+    currently_open[-1].children.append(node)
+```
 
-Debugging your parser
-=====================
+This relies on an `is_self_closing` method on `Tag`s:[^void-elements]
 
-Parsers are frequently buggy, and annoying to debug. So before we go
-further, let's make sure the parser works correctly. Let's start by
-making it easy to print the parsed HTML tree:
+[^void-elements]: The list below comes from the HTML standard's list of
+    [void elements][html5-void-elements]; a lot of them are obscure or
+    obsolete, but why not get the whole list in?
+
+[html5-void-elements]: https://html.spec.whatwg.org/multipage/syntax.html#void-elements
 
 ``` {.python}
-def print_tree(node, indent="-"):
-    if isinstance(node, ElementNode):
-        print(indent, "<{}>".format(node.tag))
-        for child in node.children:
-            print_tree(child, "  " + indent)
-    elif isinstance(node, TextNode):
-        print(indent, "\"{}\"".format(node.text))
+SELF_CLOSING_ELTS = [
+    "area", "base", "br", "col", "embed", "hr", "img", "input",
+    "link", "meta", "param", "source", "track", "wbr",
+]
+
+class Tag:
+    # ...
+    def is_self_closing(self):
+        return self.tag.split()[0].lower() in SELF_CLOSING_ELTS
+```
+
+Note that I'm doing a case-insensitive comparison[^case-insensitive]
+of the tag name, and furthermore that I'm ignoring an attributes like
+in the `meta` and `link` tags above. Now the list of open elements is
+shorter:
+
+[^case-insensitive]: This is [not the right way][case-hard] to do case
+    insensitive comparisons; the Unicode case folding algorithm should
+    be used if you want to handle languages other than English. But in
+    HTML specifically, tag names only use the ASCII characters where
+    this test is sufficient.
+    
+[case-hard]: https://www.b-list.org/weblog/2018/nov/26/case/
+
+
+```
+[<!DOCTYPE html>]
+```
+
+[html5-doctype]: https://html.spec.whatwg.org/multipage/syntax.html#the-doctype
+
+This is a special element called a [doctype][html5-doctype], and it's
+not supposed to have a close tag either. But we can't mark it a
+self-closing tag—it's always the very first thing in the document, so
+there wouldn't be an open element to append it to. And it isn't an
+element anyway; it's a bit of syntax that tells you that you're
+parsing an HTML document. Best to throw it away:
+
+``` {.python indent=8}
+elif tok.tag.split()[0].lower() == "!doctype":
+    continue
+```
+
+Now we have a new problem: a crash when a text node appears without
+any currently open elements; this text node is the newline between
+`<!DOCTYPE html>` and `<html>` in the HTML source:
+
+``` {.html}
+<!DOCTYPE html>
+<html>
+...
+```
+
+This is kind of a silly issue. It's white space, and it doesn't
+matter, after all. Let's hand it by simply skipping text nodes when
+there aren't any currently-open elements:
+
+``` {.python indent=8}
+if isinstance(tok, Text):
+    node = TextNode(tok.text)
+    if not currently_open: continue
+    currently_open[-1].children.append(node)
+```
+
+Now a tree is successfully generated and returned from our parser for
+this (and many other) web pages!
+
+::: {.further}
+
+:::
+
+
+Layout from a tree
+==================
+
+Now that we can turn a token list into an element tree, `Layout` ought
+to operate on element trees too. Let's add a `layout` method to
+replace the current `for` loop inside the constructor. To start, we
+can just call `token` twice per element node, emulating the old
+token-based layout:
+
+``` {.python indent=4}
+def layout(self, tree):
+    if isinstance(tree, TextNode):
+        self.text(tree.text)
     else:
-        raise ValueError("Unknown node type", node)
+        self.token(Tag(tree.tag))
+        for child in tree.children:
+            self.layout(child)
+        self.token(Tag("/" + tree.tag))
 ```
 
-Now it's easy to see the result of parsing an HTML document:
+This works
+
+One complication is `layout`'s local variables: the current `x` and `y`
+position, the current `bold` and `italic` state, and even that tricky
+`terminal_space` variable that took up so much time in the last chapter.
+Plus, there's the `display_list` variable for render commands. To turn
+`layout` into a recursive function, we'll need those local variables to
+become global state that multiple invocations of `layout` can share:[^6]
 
 ``` {.python}
-print_tree(parse(lex(" ... ")))
+class State:
+    def __init__(self):
+        self.x = 13
+        self.y = 13
+        self.bold = False
+        self.italic = False
+        self.terminal_space = True
+        self.dl = []
+
+state = State()
 ```
 
-Make sure to try this for several documents. Try documents without
-text, or without tags; documents without close tags; documents with
-extra whitespace before or after the root element; and so on. Most
-likely, you'll find incorrect results or crashes.
+The local variable `x` is now replaced by the field `state.x`.
 
-When you do, the best way to get more insight is to print the state of
-the parse---the current element and current token---at every parsing
-step. Walking through the output by hand will reveal a mistake. It is
-a slow but a sure process.
+The the pieces of the old `layout` function must now migrate to
+`layout_open`, `layout_close`, and `layout_text`. For example,
+`layout_open` needs to set the bold and italics flags.
+
+``` {.python}
+def layout_open(node):
+    if node.tag == "b":
+        state.bold = True
+    elif node.tag == "i":
+        state.italic = True
+```
+
+The new `layout_close` will be pretty similar (unsetting the flags),
+while `layout_text` will do the line wrapping and terminal space
+computations from the last chapter.
+
+Finally, don't forget to update `show` to get its display list from
+inside `state`.
+
+``` {.python}
+layout(nodes)
+display_list = state.display_list
+```
 
 
 Handling author errors
@@ -218,6 +410,41 @@ which spells out in detail how to handle user errors. The tweaks above
 are much more limited, but give you some sense of what the full
 algorithm is like.
 
+Debugging your parser
+=====================
+
+Parsers are frequently buggy, and annoying to debug. So before we go
+further, let's make sure the parser works correctly. Let's start by
+making it easy to print the parsed HTML tree:
+
+``` {.python}
+def print_tree(node, indent="-"):
+    if isinstance(node, ElementNode):
+        print(indent, "<{}>".format(node.tag))
+        for child in node.children:
+            print_tree(child, "  " + indent)
+    elif isinstance(node, TextNode):
+        print(indent, "\"{}\"".format(node.text))
+    else:
+        raise ValueError("Unknown node type", node)
+```
+
+Now it's easy to see the result of parsing an HTML document:
+
+``` {.python}
+print_tree(parse(lex(" ... ")))
+```
+
+Make sure to try this for several documents. Try documents without
+text, or without tags; documents without close tags; documents with
+extra whitespace before or after the root element; and so on. Most
+likely, you'll find incorrect results or crashes.
+
+When you do, the best way to get more insight is to print the state of
+the parse---the current element and current token---at every parsing
+step. Walking through the output by hand will reveal a mistake. It is
+a slow but a sure process.
+
 
 HTML attributes
 ===============
@@ -274,80 +501,6 @@ those are stripped off. The name is made lowercase before adding it to
 `self.attributes` because attribute names are case-insensitive.
 
 
-Layout from a tree
-==================
-
-Now that we can turn a token list into an element tree, `layout` ought
-to operate on element trees. Since trees have a recusive structure,
-`layout` must become a recursive function, changing its single `for`
-loop into recursive invocations of `layout`. The new `layout` will need
-to:
-
-1.  Update the state, using the rules for start tags
-2.  Recursively call `layout` for each child
-3.  Update the state, using the rules for close tags
-4.  Handle text nodes separately
-
-That suggests an implementation like this:
-
-``` {.python}
-def layout(node):
-    if isinstance(node, ElementNode):
-        layout_open(node)
-        for child in node.children:
-            layout(child)
-        layout_close(node)
-    else:
-        layout_text(node)
-```
-
-One complication is `layout`'s local variables: the current `x` and `y`
-position, the current `bold` and `italic` state, and even that tricky
-`terminal_space` variable that took up so much time in the last chapter.
-Plus, there's the `display_list` variable for render commands. To turn
-`layout` into a recursive function, we'll need those local variables to
-become global state that multiple invocations of `layout` can share:[^6]
-
-``` {.python}
-class State:
-    def __init__(self):
-        self.x = 13
-        self.y = 13
-        self.bold = False
-        self.italic = False
-        self.terminal_space = True
-        self.dl = []
-
-state = State()
-```
-
-The local variable `x` is now replaced by the field `state.x`.
-
-The the pieces of the old `layout` function must now migrate to
-`layout_open`, `layout_close`, and `layout_text`. For example,
-`layout_open` needs to set the bold and italics flags.
-
-``` {.python}
-def layout_open(node):
-    if node.tag == "b":
-        state.bold = True
-    elif node.tag == "i":
-        state.italic = True
-```
-
-The new `layout_close` will be pretty similar (unsetting the flags),
-while `layout_text` will do the line wrapping and terminal space
-computations from the last chapter.
-
-Finally, don't forget to update `show` to get its display list from
-inside `state`.
-
-``` {.python}
-layout(nodes)
-display_list = state.display_list
-```
-
-
 Summary
 =======
 
@@ -389,12 +542,6 @@ Exercises
     that contain spaces, which is valid when the attribute is quoted.
     Fix this case in the attribute parser. You will likely need to
     loop over the attribute character-by-character.
-
-[^1]: To be clear: there is additional structure, we're just ignoring
-    it for now.
-
-[^2]: Tracking the parent like I'm doing here is going to be useful for
-    parsing.
 
 [^3]: Yes, it's a crazy system, and for a few years in the early '00s
     the W3C tried to [do away with it](https://www.w3.org/TR/xhtml1/).

--- a/book/html.md
+++ b/book/html.md
@@ -485,8 +485,20 @@ no longer has to construct `Tag` objects or add slashes to things to
 indicate a close tag!
 
 ::: {.further}
-
+Document type declarations are a holdover from [SGML][sgml], the
+80s-era precursor to XML, and originally included a URL pointing to a
+full definition of the SGML variant you were using, which is no
+longer necessary. Browsers use the absense of a document type
+declaration to identify [older HTML versions][quirks-mode].[^almost-standards-mode]
 :::
+
+[sgml]: https://en.wikipedia.org/wiki/Standard_Generalized_Markup_Language
+[quirks-mode]: https://developer.mozilla.org/en-US/docs/Web/HTML/Quirks_Mode_and_Standards_Mode
+[^almost-standards-mode]: There's also a crazy thing called "[almost
+    standards][limited-quirks]" or "limited quirks" mode, due to a
+    backwards-incompatible change in table cell vertical layout. Yes.
+    I don't need to make these up!
+[limited-quirks]: https://hsivonen.fi/doctype/
 
 ``` {.python last=True}
 ```

--- a/book/signup.html
+++ b/book/signup.html
@@ -1,4 +1,3 @@
-<!-- Begin Mailchimp Signup Form -->
 <form action="https://engineering.us17.list-manage.com/subscribe/post?u=adad314c44bcc60468b0657a4&amp;id=9754ef4ff3" method="post" target="_blank" id="signup" class="states">
   <div class="s-initial">
     <h1>Get an email every time I publish a new chapter:</h1>
@@ -13,7 +12,6 @@
       <input type="email" name="EMAIL" id="signup-email" required />
     </div>
 
-    <!-- honeypot for automated spammers -->
     <div style="position: absolute; left: -5000px;" aria-hidden="true">
       <input type="text" name="b_adad314c44bcc60468b0657a4_9754ef4ff3" tabindex="-1" />
     </div>
@@ -36,4 +34,3 @@
   </div>
 </form>
 <script src="signup.js"></script>
-<!-- End Mailchimp Signup Form -->

--- a/book/template.html
+++ b/book/template.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8" />
   <meta name="generator" content="pandoc" />
-  <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=yes" />
+  <meta name="viewport" content="width=device-width,initial-scale=1.0,user-scalable=yes" />
 $for(author-meta)$  <meta name="author" content="$author-meta$" />$endfor$
 $if(prev)$  <link rel="prev" href="$prev$" />$endif$
 $if(next)$  <link rel="next" href="$next$" />$endif$

--- a/book/template.html
+++ b/book/template.html
@@ -8,8 +8,8 @@ $for(author-meta)$  <meta name="author" content="$author-meta$" />$endfor$
 $if(prev)$  <link rel="prev" href="$prev$" />$endif$
 $if(next)$  <link rel="next" href="$next$" />$endif$
 $for(css)$  <link rel="stylesheet" href="$css$" />$endfor$
-  <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Vollkorn|Lora&display=swap" />
-  <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Vollkorn:400i|Lora:400i&display=swap" />
+  <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Vollkorn%7CLora&display=swap" />
+  <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Vollkorn:400i%7CLora:400i&display=swap" />
 
   <title>$if(main)$$else$$title$ | $endif$Web Browser Engineering</title>
 $for(header-includes)$  $header-includes$$endfor$

--- a/book/text.md
+++ b/book/text.md
@@ -734,15 +734,6 @@ You can now use your browser to read an essay, a blog post, or a book!
 Exercises
 =========
 
-*Links:* The `<a>` tag[^a-for-anchor] defines links. Color them in
-blue with an underline; there's an `underline` argument to the `Font`
-constructor. Note that links normally have attributes, as in `<a
-href="...">`.
-
-[^a-for-anchor]: The `<a>` tag is short for "anchor". I don't think it
-    makes sense, but (despite an attempt to get rid of the tag in
-    XHTML 2) we're stuck with it.
-
 *Centered Text:* This book's page titles are centered: find them
 between `<h1 class="title">` and `</h1>`. Make your browser center the
 text in these titles. Each line has to be centered individually,
@@ -752,6 +743,10 @@ because different lines will have different lengths.
 should be smaller (perhaps half the normal text size) and be placed so
 that the top of a superscript lines up with the top of a normal
 letter.
+
+*Small caps:* Make the `<abbr>` element render text in small caps,
+<abbr>like this</abbr>. Upper-case letters should be in a normal font,
+while lower-case letters should be small, capitalized, and bold.
 
 *Soft hyphens:* The soft hyphen character, written `\N{soft hyphen}`
 in Python, represents a place where the text renderer can, but doesn't

--- a/book/todo.md
+++ b/book/todo.md
@@ -17,21 +17,22 @@ I am editing the chapters following the first iteration of the course.
 - [x] Debugging tips have moved out of the [Preliminaries](preliminaries.md)
 - [x] Clipping moved from [Chapter 10](reflow.md) to [Chapter 2](graphics.md) 
 - [ ] The [Preliminaries](preliminaries.md) should install Python
-- [ ] [Chapter 3](text.md) should implement multiple text sizes
-- [ ] [Chapter 4](html.md) needs to motivate attributes
+- [x] [Chapter 3](text.md) should implement multiple text sizes
+- [x] [Chapter 4](html.md) needs to motivate attributes
+- [ ] [Chapter 5](layout.md)
 - [ ] [Chapter 7](chrome.md) should add forward buttons
-- [ ] [Chapter 10](reflow.md) needs a rewrite to handle a major bug
+- [ ] [Chapter 8](forms.md) needs minor edits
+- [ ] [Chapter 10](reflow.md) needs to fix a major bug
 - [ ] [Chapter 11](security.md) must remove the straw-man insecure
   implementations
-- [ ] [Chapters 8](forms.md) needs minor edits
 
 Code
 ====
 
 I plan to have "gold-standard" code for each chapter.
 
-- [x] Code for chapters 1, 2, and 3 edited
-- [ ] Code for chapters 4, 5, 6, 7, 8, 9, 10, 11 not yet edited
+- [x] Code for chapters 1, 2, 3, and 4 edited
+- [ ] Code for chapters 5, 6, 7, 8, 9, 10, 11 not yet edited
 - [ ] [Chapter 8](forms.md) needs to abstract over finding elements
 - [ ] [Chapter 9](scripts.md) needs to split the JS environment from
   the browser
@@ -71,6 +72,5 @@ Content
 I plan tests, exercises, screenshots, and "Go further" links.
 
 - [x] Each chapter has five exercises
-- [ ] Chapter 1 & 2 have "Go further" links, the others don't
 - [ ] There are currently no tests
 - [ ] Screenshots not begun

--- a/book/todo.md
+++ b/book/todo.md
@@ -22,9 +22,11 @@ I am editing the chapters following the first iteration of the course.
 - [ ] [Chapter 5](layout.md)
 - [ ] [Chapter 7](chrome.md) should add forward buttons
 - [ ] [Chapter 8](forms.md) needs minor edits
-- [ ] [Chapter 10](reflow.md) needs to fix a major bug
+- [ ] [Chapter 10](reflow.md) needs to fix a [major bug][reflow-bug]
 - [ ] [Chapter 11](security.md) must remove the straw-man insecure
   implementations
+  
+[reflow-bug]: https://github.com/pavpanchekha/emberfox/issues/8
 
 Code
 ====

--- a/compare.py
+++ b/compare.py
@@ -101,14 +101,15 @@ if __name__ == "__main__":
         src = f.read()
     
     blocks = tangle(sys.argv[1])
-    count = 0
+    failure, count = 0, 0
     for name, block in blocks:
         block = indent(block, name.get("indent", "0"))
         block = replace(block, *[item.split("/", 1) for item in name.get("replace", "/").split(",")])
         cng = find_block(block, src)
         expected = name.get("expected", "True") == "True"
+        count += 1
         if any(l2 for l2, l in cng) == expected:
-            count += 1
+            failure += 1
             print("Block <{}> ({} lines)".format(name, block.count("\n")))
             if "hide" in name: continue
             for l2, l in cng:
@@ -119,5 +120,6 @@ if __name__ == "__main__":
                 else:
                     print(" ", l, end="")
             print()
-    print("Found differences in {} / {} blocks".format(count, len(blocks)))
-    sys.exit(count)
+        if name.get("last"): break
+    print("Found differences in {} / {} blocks".format(failure, count))
+    sys.exit(failure)

--- a/compare.py
+++ b/compare.py
@@ -109,6 +109,9 @@ if __name__ == "__main__":
         expected = name.get("expected", "True") == "True"
         count += 1
         if any(l2 for l2, l in cng) == expected:
+            # If expected to pass (True) and there are lines,
+            # or if expected to fail (False) and there are no lines,
+            # it is a failure
             failure += 1
             print("Block <{}> ({} lines)".format(name, block.count("\n")))
             if "hide" in name: continue

--- a/src/lab1.py
+++ b/src/lab1.py
@@ -1,3 +1,9 @@
+"""
+This file compiles the code in Web Browser Engineering,
+up to and including Chapter 1 (Downloading Web Pages),
+without exercises.
+"""
+
 import socket
 import ssl
 

--- a/src/lab2.py
+++ b/src/lab2.py
@@ -1,3 +1,9 @@
+"""
+This file compiles the code in Web Browser Engineering,
+up to and including Chapter 2 (Drawing to the Screen),
+without exercises.
+"""
+
 import socket
 import ssl
 import tkinter

--- a/src/lab3.py
+++ b/src/lab3.py
@@ -1,3 +1,9 @@
+"""
+This file compiles the code in Web Browser Engineering,
+up to and including Chapter 3 (Formatting Text),
+without exercises.
+"""
+
 import socket
 import ssl
 import tkinter

--- a/src/lab4.py
+++ b/src/lab4.py
@@ -1,3 +1,9 @@
+"""
+This file compiles the code in Web Browser Engineering,
+up to and including Chapter 4 (Constructing a Document Tree),
+without exercises.
+"""
+
 import socket
 import ssl
 import tkinter

--- a/src/lab4.py
+++ b/src/lab4.py
@@ -270,7 +270,7 @@ class Browser:
 if __name__ == "__main__":
     import sys
     headers, body = request(sys.argv[1])
-    text = parse(lex(body))
+    nodes = parse(lex(body))
     browser = Browser()
-    browser.layout(text)
+    browser.layout(nodes)
     tkinter.mainloop()

--- a/src/lab4.py
+++ b/src/lab4.py
@@ -1,0 +1,231 @@
+import socket
+import ssl
+import tkinter
+import tkinter.font
+
+def request(url):
+    scheme, url = url.split("://", 1)
+    assert scheme in ["http", "https"], \
+        "Unknown scheme {}".format(scheme)
+
+    host, path = url.split("/", 1)
+    path = "/" + path
+    port = 80 if scheme == "http" else 443
+
+    if ":" in host:
+        host, port = host.split(":", 1)
+        port = int(port)
+
+    s = socket.socket(
+        family=socket.AF_INET,
+        type=socket.SOCK_STREAM,
+        proto=socket.IPPROTO_TCP,
+    )
+    s.connect((host, port))
+
+    if scheme == "https":
+        ctx = ssl.create_default_context()
+        s = ctx.wrap_socket(s, server_hostname=host)
+
+    s.send(("GET {} HTTP/1.0\r\n".format(path) +
+            "Host: {}\r\n\r\n".format(host)).encode("utf8"))
+    response = s.makefile("r", encoding="utf8", newline="\r\n")
+
+    statusline = response.readline()
+    version, status, explanation = statusline.split(" ", 2)
+    assert status == "200", "{}: {}".format(status, explanation)
+
+    headers = {}
+    while True:
+        line = response.readline()
+        if line == "\r\n": break
+        header, value = line.split(":", 1)
+        headers[header.lower()] = value.strip()
+
+    body = response.read()
+    s.close()
+
+    return headers, body
+
+class Text:
+    def __init__(self, text):
+        self.text = text
+
+SELF_CLOSING_ELTS = [
+    "area", "base", "br", "col", "embed", "hr", "img", "input",
+    "link", "meta", "param", "source", "track", "wbr",
+]
+
+class Tag:
+    def __init__(self, tag):
+        self.tag = tag
+
+    def is_self_closing(self):
+        return self.tag.split()[0].lower() in SELF_CLOSING_ELTS
+
+def lex(body):
+    out = []
+    text = ""
+    in_tag = False
+    for c in body:
+        if c == "<":
+            in_tag = True
+            if text: out.append(Text(text))
+            text = ""
+        elif c == ">":
+            in_tag = False
+            out.append(Tag(text))
+            text = ""
+        else:
+            text += c
+    if not in_tag and text:
+        out.append(Text(text))
+    return out
+
+class ElementNode:
+    def __init__(self, tag):
+        self.tag = tag
+        self.children = []
+
+    def __repr__(self):
+        return "<" + self.tag + ">"
+
+class TextNode:
+    def __init__(self, text):
+        self.text = text
+        
+def parse(tokens):
+    currently_open = []
+    for tok in tokens:
+        if isinstance(tok, Text):
+            node = TextNode(tok.text)
+            if not currently_open: continue
+            currently_open[-1].children.append(node)
+        elif tok.tag.startswith("/"):
+            node = currently_open.pop()
+            if not currently_open: return node
+            currently_open[-1].children.append(node)
+        elif tok.is_self_closing():
+            node = ElementNode(tok.tag)
+            currently_open[-1].children.append(node)
+        elif tok.tag.split()[0].lower() == "!doctype":
+            continue
+        else:
+            node = ElementNode(tok.tag)
+            currently_open.append(node)
+
+WIDTH, HEIGHT = 800, 600
+HSTEP, VSTEP = 13, 18
+LINEHEIGHT = 1.2
+
+SCROLL_STEP = 100
+
+class Layout:
+    def __init__(self, tree):
+        self.display_list = []
+
+        self.x = HSTEP
+        self.y = VSTEP
+        self.weight = "normal"
+        self.style = "roman"
+        self.size = 16
+
+        self.line = []
+        self.layout(tree)
+
+    def layout(self, tree):
+        if isinstance(tree, TextNode):
+            self.text(tree.text)
+        else:
+            self.token(Tag(tree.tag))
+            for child in tree.children:
+                self.layout(child)
+            self.token(Tag("/" + tree.tag))
+
+    def token(self, tok):
+        if isinstance(tok, Text):
+            self.text(tok.text)
+        elif tok.tag == "i":
+            self.style = "italic"
+        elif tok.tag == "/i":
+            self.style = "roman"
+        elif tok.tag == "b":
+            self.weight = "bold"
+        elif tok.tag == "/b":
+            self.weight = "normal"
+        elif tok.tag == "small":
+            self.size -= 2
+        elif tok.tag == "/small":
+            self.size += 2
+        elif tok.tag == "big":
+            self.size += 4
+        elif tok.tag == "/big":
+            self.size -= 4
+        elif tok.tag == "br":
+            self.flush()
+        elif tok.tag == "/p":
+            self.flush()
+            self.y += VSTEP
+        
+    def text(self, text):
+        font = tkinter.font.Font(
+            size=self.size,
+            weight=self.weight,
+            slant=self.style,
+        )
+        for word in text.split():
+            w = font.measure(word)
+            if self.x + w > WIDTH - HSTEP:
+                self.flush()
+            self.line.append((self.x, word, font))
+            self.x += w + font.measure(" ")
+
+    def flush(self):
+        if not self.line: return
+        metrics = [font.metrics() for x, word, font in self.line]
+        max_ascent = max([metric["ascent"] for metric in metrics])
+        baseline = self.y + 1.2 * max_ascent
+        for x, word, font in self.line:
+            y = baseline - font.metrics("ascent")
+            self.display_list.append((x, y, word, font))
+        self.x = HSTEP
+        self.line = []
+        max_descent = max([metric["descent"] for metric in metrics])
+        self.y = baseline + 1.2 * max_descent
+
+class Browser:
+    def __init__(self):
+        self.window = tkinter.Tk()
+        self.canvas = tkinter.Canvas(
+            self.window,
+            width=WIDTH,
+            height=HEIGHT
+        )
+        self.canvas.pack()
+
+        self.scroll = 0
+        self.window.bind("<Down>", self.scrolldown)
+        self.display_list = []
+
+    def layout(self, tree):
+        self.display_list = Layout(tree).display_list
+        self.render()
+
+    def render(self):
+        self.canvas.delete("all")
+        for x, y, word, font in self.display_list:
+            if y > self.scroll + HEIGHT: continue
+            if y + font.metrics("linespace") < self.scroll: continue
+            self.canvas.create_text(x, y - self.scroll, text=word, font=font, anchor="nw")
+
+    def scrolldown(self, e):
+        self.scroll += SCROLL_STEP
+        self.render()
+
+if __name__ == "__main__":
+    import sys
+    headers, body = request(sys.argv[1])
+    text = parse(lex(body))
+    browser = Browser()
+    browser.layout(text)
+    tkinter.mainloop()

--- a/src/lab4.py
+++ b/src/lab4.py
@@ -176,15 +176,15 @@ class Layout:
         self.size = 16
 
         self.line = []
-        self.layout(tree)
+        self.recurse(tree)
 
-    def layout(self, tree):
+    def recurse(self, tree):
         if isinstance(tree, TextNode):
             self.text(tree.text)
         else:
             self.open(tree.tag)
             for child in tree.children:
-                self.layout(child)
+                self.recurse(child)
             self.close(tree.tag)
 
     def open(self, tag):

--- a/www/book.css
+++ b/www/book.css
@@ -13,6 +13,8 @@ pre { font-size: 80%; overflow: auto; }
 dt { margin-top: 1em; }
 dd { margin-bottom: 1em; }
 
+abbr { font-variant: small-caps; font-weight: bold; }
+
 blockquote { border-left: 1ex solid #eee; padding-left: 1ex; margin-left: 0; }
 
 footer { text-align: center; font: italic 60% serif; margin: 5em 0; }


### PR DESCRIPTION
This PR is a complete editing pass on the HTML chapter. Some of the major changes include:

- [x] The parser has been reorganized to more closely match a standard LR parser
- [x] Self-closing elements and doctypes are dealt with in the text instead of the exercises
- [x] Attributes are sort-of justified by the self-closing tags
- [x] The `Layout` object makes the recursive layout algorithm a lot cleaner
- [x] The author errors handled are now the implicit open and close tags: more useful than the prior example and better matching real HTML parsers.