### PR TITLE
Ignore whitespace text nodes in the HTML parser

### DIFF
--- a/book/html.md
+++ b/book/html.md
@@ -316,7 +316,7 @@ all text nodes that only contain whitespace:[^ignore-them]
 [^ignore-them]: Real browsers retain whitespace nodes: whitespace is
     significant inside `<pre>` tags and in some other cases. But our
     browser already renders `He<b>llo</b>` as two words, so let's just
-    say it's not a focus. Plus, ignoring all whitespace tags simplifies
+    ignore that complication. Plus, ignoring all whitespace tags simplifies
     [later chapters](layout.md) by avoiding special-case reasoning
     about whitespace-only text tags.
 

--- a/book/html.md
+++ b/book/html.md
@@ -310,13 +310,20 @@ Furthermore, text can appear after the doctype declaration but before
 any other elements; in that case `currently_open` is empty so there's
 no node to add that text to. Usually that text is just whitespace
 between `<!DOCTYPE html>` and `<html>` in the HTML source, so it's
-silly to have the parser crash here. Let's hand it by simply skipping
-text nodes when there aren't any currently-open elements:
+silly to have the parser crash here. Let's handle it just skipping
+all text nodes that only contain whitespace:[^ignore-them]
+
+[^ignore-them]: Real browsers retain whitespace nodes: whitespace is
+    significant inside `<pre>` tags and in some other cases. But our
+    browser already renders `He<b>llo</b>` as two words, so let's just
+    say it's not a focus. Plus, ignoring all whitespace tags simplifies
+    [later chapters](layout.md) by avoiding special-case reasoning
+    about whitespace-only text tags.
 
 ``` {.python indent=8}
 if isinstance(tok, Text):
+    if tok.text.isspace(): continue
     node = TextNode(tok.text)
-    if not currently_open: continue
     currently_open[-1].children.append(node)
 ```
 

--- a/src/lab4.py
+++ b/src/lab4.py
@@ -121,8 +121,8 @@ def parse(tokens):
     for tok in tokens:
         implicit_tags(tok, currently_open)
         if isinstance(tok, Text):
+            if tok.text.isspace(): continue
             node = TextNode(tok.text)
-            if not currently_open: continue
             currently_open[-1].children.append(node)
         elif tok.tag.startswith("/"):
             node = currently_open.pop()


### PR DESCRIPTION
This modifies the HTML parser to ignore all whitespace nodes. It's not a big change and it's a little weird, but I think it avoids other weird special cases later in the book.