### PR TITLE
Publish text chapter

### DIFF
--- a/book/text.md
+++ b/book/text.md
@@ -611,15 +611,26 @@ def text(self, text):
         self.line.append((self.x, word, font))
 ```
 
-The second phase, meanwhile, needs to happen when we're finished with
-a line; I'm calling that second phase `flush()`:
+The new `line` field is essentially a buffer, where words are held
+temporarily before they can be placed. The second phase is that buffer
+being flushed when we're finished with a line:
 
-``` {.python}
+``` {.python indent=12}
 if self.x + w > WIDTH - HSTEP:
     self.flush()
 ```
 
-This new `flush` function has three main responsibilities:
+As usual with buffers, we also need to make sure the buffer is flushed
+once all tokens are processed:
+
+``` {.python}
+class Layout:
+    def __init__(self, tokens):
+        # ...
+        self.flush()
+```
+
+This new `flush` function has three responsibilities:
 
 1. It must align the words along the line;
 2. It must add all those words to the display list; and
@@ -694,7 +705,7 @@ the current line and starts a new one:
     this. Some people like adding a final slash to self-closing tags,
     like `<br/>`, but this is not required in HTML.
 
-``` {.python}
+``` {.python indent=4}
 def token(self, tok):
     # ...
     elif tok.tag == "br":

--- a/book/text.md
+++ b/book/text.md
@@ -63,16 +63,24 @@ world of magic ink.
     the computer how to best to align it to the pixel grid.
 
 Yet Tk's *font objects* correspond to the older meaning of font: a
-type at a fixed size, style, and weight. For example:
+type at a fixed size, style, and weight. For example:[^after-tk]
+
+[^after-tk]: You can only create `Font` objects, or any other kinds of
+    Tk objects, after calling `tkinter.Tk()`, which is why I'm putting
+    this code in the Browser constructor.
 
 ``` {.python expected=False}
 import tkinter.font
-bi_times = tkinter.font.Font(
-    family="Times",
-    size=16,
-    weight="bold",
-    slant="italic",
-)
+
+class Browser:
+    def __init__(self):
+        # ...
+        bi_times = tkinter.font.Font(
+            family="Times",
+            size=16,
+            weight="bold",
+            slant="italic",
+        )
 ```
 
 ::: {.quirk}

--- a/disabled.conf
+++ b/disabled.conf
@@ -3,7 +3,7 @@ preliminaries.md
 
 # html.md
 # graphics.md
-text.md
+# text.md
 html.md
 layout.md
 styles.md

--- a/src/lab3.py
+++ b/src/lab3.py
@@ -100,6 +100,7 @@ class Layout:
         self.line = []
         for tok in tokens:
             self.token(tok)
+        self.flush()
 
     def token(self, tok):
         if isinstance(tok, Text):


### PR DESCRIPTION
This PR makes Chapter 3 (Formatting Text) public. As part of that, this PR:

- [x] Clarifies that font commands can only be run after `tkinter.Tk()` is executed
- [x] Makes sure to call `flush` after all tokens have been processed, so that the last line of the document is drawn
- [x] Characterizes `Layout.line` as a buffer, to cast flush-after-last-token as a general pattern

It does *not*:

- [ ] Introduce a font cache. This is very important to making the browser fast on Windows and some forms of Linux. But it's a big change that might be better relegated to a debugging section, which might even teach you to use a profiler.