### PR TITLE
Add attributes and parent pointers in the HTML chapter

### DIFF
--- a/book/chrome.md
+++ b/book/chrome.md
@@ -298,8 +298,7 @@ def handle_click(self, e):
 
 Note the `while` loop. That's because the most specific thing the user
 clicked on is a `TextNode`; we need to walk up the HTML tree to find
-an `ElementNode` that is a link. To do this, you'll need to add a
-`parent` field to `ElementNode`s, so make sure to do that.
+an `ElementNode` that is a link.
 
 Once we've found the link, we need to navigate to that page. That
 would mean:

--- a/book/html.md
+++ b/book/html.md
@@ -51,8 +51,10 @@ That tree can also contain text at the leaves:
 
 ```
 class TextNode:
-    def __init__(self, text):
+    def __init__(self, text, parent):
         self.text = text
+        self.parent = parent
+        self.children = []
 ```
 
 Element nodes start empty, and our parser fills them in. The idea is
@@ -75,8 +77,9 @@ open element.
 
 ``` {.python indent=8}
 if isinstance(tok, Text):
-    node = TextNode(tok.text)
-    currently_open[-1].children.append(node)
+    parent = currently_open[-1]
+    node = TextNode(tok.text, parent)
+    parent.children.append(node)
 ```
 
 End tags are similar, but instead of making a new node they take the
@@ -344,17 +347,16 @@ silly to have the parser crash here. Let's handle it just skipping
 all text nodes that only contain whitespace:[^ignore-them]
 
 [^ignore-them]: Real browsers retain whitespace nodes: whitespace is
-    significant inside `<pre>` tags and in some other cases. But our
-    browser already renders `He<b>llo</b>` as two words, so let's just
-    ignore that complication. Plus, ignoring all whitespace tags simplifies
-    [later chapters](layout.md) by avoiding special-case reasoning
-    about whitespace-only text tags.
+    significant inside `<pre>` tags or in cases like the difference
+    between `make<span>up</span>` and `make <span>up</span>`. Our
+    browser won't support that, and ignoring all whitespace tags
+    simplifies [later chapters](layout.md) by avoiding a special-case
+    for whitespace-only text tags.
 
 ``` {.python indent=8}
 if isinstance(tok, Text):
     if tok.text.isspace(): continue
-    node = TextNode(tok.text)
-    currently_open[-1].children.append(node)
+    # ...
 ```
 
 With this change, the parser can now parse this page, and most other

--- a/book/html.md
+++ b/book/html.md
@@ -58,16 +58,24 @@ class TextNode:
 ```
 
 Element nodes start empty, and our parser fills them in. The idea is
-simple: keep track of the currently open elements, and any time we
-finish a node (at a text or end tag token) we add it to the
-bottom-most currently-open element. Let's store the currently open
-elements in a list, from top to bottom:
+simple: keep track of the currently open elements, a list from top to bottom:
 
 ``` {.python}
 def parse(tokens):
     currently_open = []
     for tok in tokens:
         # ...
+```
+
+The *end* of this list---the most recently opened element---is the
+parent of any new nodes we come across. Any time we finish a node (at
+a text or end tag token) the last thing in the `currently_open` list
+is its parent:
+
+``` {.python}
+for tok in tokens:
+    parent = currently_open[-1] if currently_open else None
+    # ...
 ```
 
 Inside the loop, we need to figure out if the token is text, an open
@@ -77,7 +85,6 @@ open element.
 
 ``` {.python indent=8}
 if isinstance(tok, Text):
-    parent = currently_open[-1]
     node = TextNode(tok.text, parent)
     parent.children.append(node)
 ```
@@ -96,10 +103,6 @@ it to the list of currently open elements:
 
 ``` {.python indent=8 replace=parent)/parent%2c%20tok.attributes)}
 else:
-    if currently_open:
-        parent = currently_open[-1]
-    else:
-        parent = None
     node = ElementNode(tok.tag, parent)
     currently_open.append(node)
 ```
@@ -188,7 +191,6 @@ because they never surround content. Let's add that to our parser:
 ``` {.python indent=8 replace=parent)/parent%2c%20tok.attributes)}
 # ...
 elif tok.tag in SELF_CLOSING_TAGS:
-    parent = currently_open[-1]
     node = ElementNode(tok.tag, parent)
     parent.children.append(node)
 ```

--- a/book/styles.md
+++ b/book/styles.md
@@ -27,25 +27,9 @@ It looks like this:
 It's a `<div>` element with its `style` attribute set. That attribute
 contains two key-value pairs, which set `margin-left` and
 `margin-right` to 10 pixels each.^[CSS allows spaces around the
-punctuation, but your attribute parser may not support it.] We want to
+punctuation, but our attribute parser does not support it.] We want to
 store these pairs in a `style` field on the `ElementNode` so we can
-consult them during layout.
-
-The first step is adding attributes to `ElementNode`s; attributes are
-currently stored in `Tag`s but not `ElementNode`s:
-
-``` {.python}
-class ElementNode:
-    def __init__(self, tag, attributes):
-        self.tag = tag
-        self.attributes = attributes
-        self.children = []
-```
-
-These attributes need to be passed from the token to the `ElementNode`
-it creates, both in `parse` and in `implicit_tags`. With the
-attributes stored on the `ElementNode`, we can extract[^python-get]
-and parse the `style` attribute in particular:
+consult them during layout:[^python-get]
 
 [^python-get]: The `get` method for dictionaries gets a value out of a
     dictionary, or uses a default value if it's not present.
@@ -61,19 +45,12 @@ class ElementNode:
             self.style[prop.strip().lower()] = val.strip()
 ```
 
-With these changes, each `ElementNode` should now have a `style`
-field with any stylistic choices made by the author.
-
-The CSS box model
-=================
-
-It'd be nice to have some stylistic properties for authors to
-manipulate with this `style` attribute. Let's add support for
-*margins*, *borders*, and *padding*, which change the position of
-block layout objects. Here's how those work. In effect, every block
-has four rectangles associated with it: the *margin rectangle*, the
-*border rectangle*, the *padding rectangle*, and the *content
-rectangle*:
+Each `ElementNode` now has a `style` field with any stylistic choices
+made by the author. Let's add support for *margins*, *borders*, and
+*padding*, which change the position of block layout objects. Here's
+how those work. In effect, every block has four rectangles associated
+with it: the *margin rectangle*, the *border rectangle*, the *padding
+rectangle*, and the *content rectangle*:
 
 ![](https://www.w3.org/TR/CSS2/images/boxdim.png)
 

--- a/src/lab4.py
+++ b/src/lab4.py
@@ -123,10 +123,11 @@ class TextNode:
 def parse(tokens):
     currently_open = []
     for tok in tokens:
+        parent = currently_open[-1] if currently_open else None
+
         implicit_tags(tok, currently_open)
         if isinstance(tok, Text):
             if tok.text.isspace(): continue
-            parent = currently_open[-1]
             node = TextNode(tok.text, parent)
             parent.children.append(node)
         elif tok.tag.startswith("/"):
@@ -134,16 +135,11 @@ def parse(tokens):
             if not currently_open: return node
             currently_open[-1].children.append(node)
         elif tok.tag in SELF_CLOSING_TAGS:
-            parent = currently_open[-1]
             node = ElementNode(tok.tag, tok.attributes, parent)
             parent.children.append(node)
         elif tok.tag.startswith("!"):
             continue
         else:
-            if currently_open:
-                parent = currently_open[-1]
-            else:
-                parent = None
             node = ElementNode(tok.tag, parent, tok.attributes)
             currently_open.append(node)
     while currently_open:

--- a/src/lab4.py
+++ b/src/lab4.py
@@ -112,8 +112,10 @@ class ElementNode:
         return "<" + self.tag + ">"
 
 class TextNode:
-    def __init__(self, text):
+    def __init__(self, text, parent):
         self.text = text
+        self.parent = parent
+        self.children = []
 
     def __repr__(self):
         return self.text.replace("\n", "\\n")
@@ -124,8 +126,9 @@ def parse(tokens):
         implicit_tags(tok, currently_open)
         if isinstance(tok, Text):
             if tok.text.isspace(): continue
-            node = TextNode(tok.text)
-            currently_open[-1].children.append(node)
+            parent = currently_open[-1]
+            node = TextNode(tok.text, parent)
+            parent.children.append(node)
         elif tok.tag.startswith("/"):
             node = currently_open.pop()
             if not currently_open: return node

--- a/src/lab4.py
+++ b/src/lab4.py
@@ -102,8 +102,9 @@ def lex(body):
     return out
 
 class ElementNode:
-    def __init__(self, tag):
+    def __init__(self, tag, attributes):
         self.tag = tag
+        self.attributes = attributes
         self.children = []
 
     def __repr__(self):
@@ -129,12 +130,12 @@ def parse(tokens):
             if not currently_open: return node
             currently_open[-1].children.append(node)
         elif tok.tag in SELF_CLOSING_TAGS:
-            node = ElementNode(tok.tag)
+            node = ElementNode(tok.tag, tok.attributes)
             currently_open[-1].children.append(node)
         elif tok.tag.startswith("!"):
             continue
         else:
-            node = ElementNode(tok.tag)
+            node = ElementNode(tok.tag, tok.attributes)
             currently_open.append(node)
     while currently_open:
         node = currently_open.pop()
@@ -151,17 +152,17 @@ def implicit_tags(tok, currently_open):
     while True:
         open_tags = [node.tag for node in currently_open]
         if open_tags == [] and tag != "html":
-            currently_open.append(ElementNode("html"))
+            currently_open.append(ElementNode("html", {}))
         elif open_tags == ["html"] and tag not in ["head", "body", "/html"]:
             if tag in HEAD_TAGS:
                 implicit = "head"
             else:
                 implicit = "body"
-            currently_open.append(ElementNode(implicit))
+            currently_open.append(ElementNode(implicit, {}))
         elif open_tags == ["html", "head"] and tag not in ["/head"] + HEAD_TAGS:
             node = currently_open.pop()
             currently_open[-1].children.append(node)
-            currently_open.append(ElementNode("body"))
+            currently_open.append(ElementNode("body", {}))
         else:
             break
 

--- a/src/lab4.py
+++ b/src/lab4.py
@@ -102,8 +102,9 @@ def lex(body):
     return out
 
 class ElementNode:
-    def __init__(self, tag, attributes):
+    def __init__(self, tag, parent, attributes):
         self.tag = tag
+        self.parent = parent
         self.attributes = attributes
         self.children = []
 
@@ -130,12 +131,17 @@ def parse(tokens):
             if not currently_open: return node
             currently_open[-1].children.append(node)
         elif tok.tag in SELF_CLOSING_TAGS:
-            node = ElementNode(tok.tag, tok.attributes)
-            currently_open[-1].children.append(node)
+            parent = currently_open[-1]
+            node = ElementNode(tok.tag, tok.attributes, parent)
+            parent.children.append(node)
         elif tok.tag.startswith("!"):
             continue
         else:
-            node = ElementNode(tok.tag, tok.attributes)
+            if currently_open:
+                parent = currently_open[-1]
+            else:
+                parent = None
+            node = ElementNode(tok.tag, parent, tok.attributes)
             currently_open.append(node)
     while currently_open:
         node = currently_open.pop()
@@ -152,17 +158,18 @@ def implicit_tags(tok, currently_open):
     while True:
         open_tags = [node.tag for node in currently_open]
         if open_tags == [] and tag != "html":
-            currently_open.append(ElementNode("html", {}))
+            currently_open.append(ElementNode("html", None, {}))
         elif open_tags == ["html"] and tag not in ["head", "body", "/html"]:
             if tag in HEAD_TAGS:
                 implicit = "head"
             else:
                 implicit = "body"
-            currently_open.append(ElementNode(implicit, {}))
+            parent = currently_open[-1]
+            currently_open.append(ElementNode(implicit, parent, {}))
         elif open_tags == ["html", "head"] and tag not in ["/head"] + HEAD_TAGS:
             node = currently_open.pop()
-            currently_open[-1].children.append(node)
-            currently_open.append(ElementNode("body", {}))
+            parent = currently_open[-1]
+            parent.children.append(node)
         else:
             break
 

--- a/src/lab5.py
+++ b/src/lab5.py
@@ -104,6 +104,7 @@ def lex(body):
 class ElementNode:
     def __init__(self, tag):
         self.tag = tag
+        self.attributes = attributes
         self.children = []
 
     def __repr__(self):
@@ -129,12 +130,12 @@ def parse(tokens):
             if not currently_open: return node
             currently_open[-1].children.append(node)
         elif tok.tag in SELF_CLOSING_TAGS:
-            node = ElementNode(tok.tag)
+            node = ElementNode(tok.tag, tok.attributes)
             currently_open[-1].children.append(node)
         elif tok.tag.startswith("!"):
             continue
         else:
-            node = ElementNode(tok.tag)
+            node = ElementNode(tok.tag, tok.attributes)
             currently_open.append(node)
     while currently_open:
         node = currently_open.pop()
@@ -151,17 +152,17 @@ def implicit_tags(tok, currently_open):
     while True:
         open_tags = [node.tag for node in currently_open]
         if open_tags == [] and tag != "html":
-            currently_open.append(ElementNode("html"))
+            currently_open.append(ElementNode("html", {}))
         elif open_tags == ["html"] and tag not in ["head", "body", "/html"]:
             if tag in HEAD_TAGS:
                 implicit = "head"
             else:
                 implicit = "body"
-            currently_open.append(ElementNode(implicit))
+            currently_open.append(ElementNode(implicit, {}))
         elif open_tags == ["html", "head"] and tag not in ["/head"] + HEAD_TAGS:
             node = currently_open.pop()
             currently_open[-1].children.append(node)
-            currently_open.append(ElementNode("body"))
+            currently_open.append(ElementNode("body", {}))
         else:
             break
 

--- a/src/lab5.py
+++ b/src/lab5.py
@@ -123,10 +123,11 @@ class TextNode:
 def parse(tokens):
     currently_open = []
     for tok in tokens:
+        parent = currently_open[-1] if currently_open else None
+
         implicit_tags(tok, currently_open)
         if isinstance(tok, Text):
             if tok.text.isspace(): continue
-            parent = currently_open[-1]
             node = TextNode(tok.text, parent)
             parent.children.append(node)
         elif tok.tag.startswith("/"):
@@ -134,16 +135,11 @@ def parse(tokens):
             if not currently_open: return node
             currently_open[-1].children.append(node)
         elif tok.tag in SELF_CLOSING_TAGS:
-            parent = currently_open[-1]
             node = ElementNode(tok.tag, tok.attributes, parent)
             parent.children.append(node)
         elif tok.tag.startswith("!"):
             continue
         else:
-            if currently_open:
-                parent = currently_open[-1]
-            else:
-                parent = None
             node = ElementNode(tok.tag, parent, tok.attributes)
             currently_open.append(node)
     while currently_open:

--- a/src/lab5.py
+++ b/src/lab5.py
@@ -112,8 +112,10 @@ class ElementNode:
         return "<" + self.tag + ">"
 
 class TextNode:
-    def __init__(self, text):
+    def __init__(self, text, parent):
         self.text = text
+        self.parent = parent
+        self.children = []
 
     def __repr__(self):
         return self.text.replace("\n", "\\n")
@@ -123,9 +125,10 @@ def parse(tokens):
     for tok in tokens:
         implicit_tags(tok, currently_open)
         if isinstance(tok, Text):
-            node = TextNode(tok.text)
-            if not currently_open: continue
-            currently_open[-1].children.append(node)
+            if tok.text.isspace(): continue
+            parent = currently_open[-1]
+            node = TextNode(tok.text, parent)
+            parent.children.append(node)
         elif tok.tag.startswith("/"):
             node = currently_open.pop()
             if not currently_open: return node

--- a/src/lab6.py
+++ b/src/lab6.py
@@ -129,10 +129,11 @@ class TextNode:
 def parse(tokens):
     currently_open = []
     for tok in tokens:
+        parent = currently_open[-1] if currently_open else None
+
         implicit_tags(tok, currently_open)
         if isinstance(tok, Text):
             if tok.text.isspace(): continue
-            parent = currently_open[-1]
             node = TextNode(tok.text, parent)
             parent.children.append(node)
         elif tok.tag.startswith("/"):
@@ -140,16 +141,11 @@ def parse(tokens):
             if not currently_open: return node
             currently_open[-1].children.append(node)
         elif tok.tag in SELF_CLOSING_TAGS:
-            parent = currently_open[-1]
             node = ElementNode(tok.tag, tok.attributes, parent)
             parent.children.append(node)
         elif tok.tag.startswith("!"):
             continue
         else:
-            if currently_open:
-                parent = currently_open[-1]
-            else:
-                parent = None
             node = ElementNode(tok.tag, parent, tok.attributes)
             currently_open.append(node)
     while currently_open:

--- a/src/lab6.py
+++ b/src/lab6.py
@@ -118,8 +118,9 @@ class ElementNode:
         return "<" + self.tag + ">"
 
 class TextNode:
-    def __init__(self, text):
+    def __init__(self, text, parent):
         self.text = text
+        self.parent = parent
         self.children = []
 
     def __repr__(self):
@@ -130,9 +131,10 @@ def parse(tokens):
     for tok in tokens:
         implicit_tags(tok, currently_open)
         if isinstance(tok, Text):
-            node = TextNode(tok.text)
-            if not currently_open: continue
-            currently_open[-1].children.append(node)
+            if tok.text.isspace(): continue
+            parent = currently_open[-1]
+            node = TextNode(tok.text, parent)
+            parent.children.append(node)
         elif tok.tag.startswith("/"):
             node = currently_open.pop()
             if not currently_open: return node


### PR DESCRIPTION
This PR adds the `attributes` and `parent` properties to `ElementNode`s, and `parent` and (empty) `children` properties to `TextNode`s. The `ElementNode` changes are required by later chapters, so it makes sense to do them here, and they also clarify the stack handling in the parser just a little bit.