### PR TITLE
Add notes about screen coordinates and touch gestures, and make pandoc treat warnings as errors

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,17 +2,19 @@ FLAGS=
 
 ORDERED_PAGES=preface preliminaries http graphics text html layout styles chrome forms scripts reflow security advanced-rendering skipped change
 
+PANDOC_COMMON_ARGS=--from markdown --to html --lua-filter=book/filter.lua --fail-if-warnings
+
 book: $(patsubst book/%.md,www/%.html,$(wildcard book/*.md)) www/draft/onepage.html
 blog: $(patsubst blog/%.md,www/blog/%.html,$(wildcard blog/*.md))
 draft: $(patsubst book/%.md,www/draft/%.html,$(wildcard book/*.md))
 
 onepage/%.html: book/%.md book/template-onepage.html book/filter.lua disabled.conf
 	mkdir -p $(dir $@)
-	pandoc --toc --template book/template-onepage.html $(FLAGS) -c book.css --variable=script:feedback.js --from markdown --to html --lua-filter=book/filter.lua --metadata=mode:draft -c ../book.css $< -o $@
+	pandoc --toc --template book/template-onepage.html $(FLAGS) -c book.css --variable=script:feedback.js $(PANDOC_COMMON_ARGS) --metadata=mode:draft -c ../book.css $< -o $@
 
 onepage/%-quicklink.html: book/%.md book/quicklink.html book/filter.lua disabled.conf
 	mkdir -p $(dir $@)
-	pandoc --toc --template book/quicklink.html $(FLAGS) --variable=script:feedback.js --from markdown --to html --lua-filter=book/filter.lua $< -o $@
+	pandoc --toc --template book/quicklink.html $(FLAGS) --variable=script:feedback.js $(PANDOC_COMMON_ARGS) $< -o $@
 
 www/draft/onepage.html: $(patsubst book/%.md,onepage/%.html,$(wildcard book/*.md)) $(patsubst book/%.md,onepage/%-quicklink.html,$(wildcard book/*.md)) book/onepage-head.html
 	mkdir -p $(dir $@)
@@ -20,17 +22,17 @@ www/draft/onepage.html: $(patsubst book/%.md,onepage/%.html,$(wildcard book/*.md
 
 www/%.html: book/%.md book/template.html book/signup.html book/filter.lua disabled.conf
 	mkdir -p $(dir $@)
-	pandoc --toc --template book/template.html $(FLAGS) -c book.css --variable=script:feedback.js --from markdown --to html --lua-filter=book/filter.lua $< -o $@
+	pandoc --toc --template book/template.html $(FLAGS) -c book.css --variable=script:feedback.js $(PANDOC_COMMON_ARGS) $< -o $@
 
 www/blog/%.html: blog/%.md book/template.html book/filter.lua disabled.conf
 	mkdir -p $(dir $@)
-	pandoc --metadata=toc:none --template book/template.html $(FLAGS) -c ../book.css --from markdown --to html --lua-filter=book/filter.lua $< -o $@
+	pandoc --metadata=toc:none --template book/template.html $(FLAGS) -c ../book.css $(PANDOC_COMMON_ARGS) $< -o $@
 
 www/draft/%.html: book/%.md book/template.html book/signup.html book/filter.lua
 	@ mkdir -p $(dir $@)
 	pandoc --toc --template book/template.html $(FLAGS) \
 	       --metadata=mode:draft --variable=script:../feedback.js \
-               -c ../book.css --from markdown --to html --lua-filter=book/filter.lua \
+               -c ../book.css $(PANDOC_COMMON_ARGS) \
                $< -o $@
 
 publish:

--- a/book/graphics.md
+++ b/book/graphics.md
@@ -294,7 +294,7 @@ page---draws everything---in terms of screen coordinates.[^screen-coordinates]
 
 [^screen-coordinates]: Sort of. What actually happens is that the page is
 first drawn into a bitmap or GPU texture, then that bitmap/texture is shifted
-according to the scroll, and the result is rendered to the screen. Chapter 12
+according to the scroll, and the result is rendered to the screen. [Chapter 12][advanced-rendering.md]
 will have more on this topic.
 
 Our browser will have the same split. Right now `layout` both computes

--- a/book/graphics.md
+++ b/book/graphics.md
@@ -290,7 +290,12 @@ coordinates (since you've scrolled 60 pixels down, this text is 72
 pixels from the top of the *screen*). Generally speaking, a browser
 *lays out* the page---determines where everything on the page
 goes---in terms of page coordinates and then *renders* the
-page---draws everything---in terms of screen coordinates.
+page---draws everything---in terms of screen coordinates.[^screen-coordinates]
+
+[^screen-coordinates]: Sort of. What actually happens is that the page is
+first drawn into a bitmap or GPU texture, then that bitmap/texture is shifted
+according to the scroll, and the result is rendered to the screen. Chapter 12
+will have more on this topic.
 
 Our browser will have the same split. Right now `layout` both computes
 the position of each character and draws it: layout and rendering.
@@ -358,8 +363,8 @@ Reacting to the user
 ====================
 
 Most browsers scroll the page when you press the up and down keys,
-rotate the scroll wheel, or drag the scroll bar. To keep things simple,
-let's just implement the down key.
+rotate the scroll wheel, drag the scroll bar, or apply a touch gesture to the
+screen. To keep things simple, let's just implement the down key.
 
 Tk allows you to *bind* a function to a key, which instructs Tk to
 call that function when the key is pressed. For example, to bind to
@@ -511,7 +516,7 @@ wheel.[^laptop-mousewheel] The associated event object has an
 `event.delta` value which tells you how far and in what direction to
 scroll.
 
-[^laptop-mousewheel]: It also seems to trigger with touchpad gestures,
+[^laptop-mousewheel]: It will also trigger with touchpad gestures,
     if you don't have a mouse.
 
 *Emoji*: Add support for emoji 😀 to our browser. Emoji are


### PR DESCRIPTION
Now if there is a footnote typo, the build will fail.