### PR TITLE
Change layout to reference the previous sibling

### DIFF
--- a/book/layout.md
+++ b/book/layout.md
@@ -123,7 +123,6 @@ def __init__(self, node, parent, previous):
     self.parent = parent
     self.previous = previous
     self.children = []
-    # ...
 ```
 
 The `InlineLayout` constructor also initializes `weight`, `style`, and
@@ -176,7 +175,7 @@ of layout object:
 
 ``` {.python}
 class BlockLayout:
-    def __init__(self, node, parent):
+    def __init__(self, node, parent, previous):
         self.node = node
         self.parent = parent
         self.children = []
@@ -399,7 +398,8 @@ tree and lay it out:
 
 ``` {.python}
 class Browser:
-    def layout(self, tree):
+    def layout(self, body):
+        tree = HTMLParser(body).parse()
         document = DocumentLayout(tree)
         document.layout()
 ```
@@ -446,7 +446,7 @@ variable:
 
 ``` {.python}
 class Browser:
-    def layout(self, tree):
+    def layout(self, body):
         # ...
         self.display_list = []
         document.draw(self.display_list)
@@ -594,7 +594,7 @@ past the bottom of the page. In `layout`, store the height in a
 `max_y` variable:
 
 ``` {.python}
-def layout(self, tree):
+def layout(self, body):
     # ...
     self.max_y = document.h - HEIGHT
 ```
@@ -606,7 +606,7 @@ bottom of the page:
 def scrolldown(self, e):
     self.scroll = self.scroll + SCROLL_STEP
     self.scroll = min(self.scroll, self.max_y)
-    self.scroll = max(0, self.scroll))
+    self.scroll = max(0, self.scroll)
     self.render()
 ```
 

--- a/book/layout.md
+++ b/book/layout.md
@@ -113,8 +113,8 @@ class BlockLayout:
 ```
 
 These layout objects will be the nodes of a *layout tree*. So we'll
-want layout objects to have children, a parent, and an HTML element
-that they correspond to. Each layout object will also have a layout to
+want layout objects to have references to their children, a parent, and an HTML element
+that they correspond to. Each layout object will also have a reference to
 its previous sibling in the tree.
 
 ``` {.python}
@@ -144,7 +144,7 @@ def layout(self):
     self.flush()
 ```
 
-Besides the references to other layout object, each layout object also
+Besides the references to other related layout objects, each layout object also
 needs a size and position, which we'll store in the `w`, `h`, `x`, and
 `y` fields.
 
@@ -331,7 +331,7 @@ object can be computed:
 self.h = sum([child.h for child in self.children])
 ```
 
-Note how important the order is here. A block layout's width depends
+Note how important the order is here. A block layout object's width depends
 on the parent's width; so by symmetry the width must be computed
 before laying out the children. The position is the same: it has to be
 computed before recursing so it's already available when the children

--- a/book/layout.md
+++ b/book/layout.md
@@ -377,8 +377,13 @@ class DocumentLayout:
         self.x = HSTEP
         self.y = VSTEP
         child.layout()
-        self.h = child.h
+        self.h = child.h + 2*VSTEP
 ```
+
+Note that I'm adding a little bit of padding around the main
+text---`HSTEP` on the left and right, and `VSTEP` above. That's so the
+text won't run into the very edge of the window, where a bit of it
+would get cut off.
 
 To summarize the rules of layout computation:
 

--- a/book/layout.md
+++ b/book/layout.md
@@ -114,12 +114,14 @@ class BlockLayout:
 
 These layout objects will be the nodes of a *layout tree*. So we'll
 want layout objects to have children, a parent, and an HTML element
-that they correspond to:
+that they correspond to. Each layout object will also have a layout to
+its previous sibling in the tree.
 
 ``` {.python}
-def __init__(self, node, parent):
+def __init__(self, node, parent, previous):
     self.node = node
     self.parent = parent
+    self.previous = previous
     self.children = []
     # ...
 ```
@@ -143,18 +145,9 @@ def layout(self):
     self.flush()
 ```
 
-Besides a node, a parent, and children, each layout object also needs
-a size and position, which we'll store in the `w`, `h`, `x`, and `y`
-fields:
-
-``` {.python}
-def __init__(self, node, parent):
-    # ...
-    self.x = -1
-    self.y = -1
-    self.w = -1
-    self.h = -1
-```
+Besides the references to other layout object, each layout object also
+needs a size and position, which we'll store in the `w`, `h`, `x`, and
+`y` fields.
 
 Unfortunately, `InlineLayout` already uses the `x` and `y` fields for
 the location of the next word. To avoid a *very* annoying conflict,
@@ -187,11 +180,6 @@ class BlockLayout:
         self.node = node
         self.parent = parent
         self.children = []
-
-        self.x = -1
-        self.y = -1
-        self.w = -1
-        self.h = -1
 
     def layout(self):
         # ...
@@ -233,8 +221,7 @@ whether it should have block or inline contents:
 def has_block_children(self):
     for child in self.node.children:
         if isinstance(child, TextNode):
-            if not child.text.isspace():
-                return False
+            return False
         elif child.tag in INLINE_ELEMENTS:
             return False
     return True
@@ -246,11 +233,12 @@ create child layout objects:
 ``` {.python indent=4}
 def layout(self):
     if self.has_block_children():
+        previous = None
         for child in self.node.children:
-            if isinstance(child, TextNode): continue
-            self.children.append(BlockLayout(child, self))
+            previous = BlockLayout(child, self, previous)
+            self.children.append(previous)
     else:
-        self.children.append(InlineLayout(self.node, self))
+        self.children.append(InlineLayout(self.node, self, None))
 ```
 
 Note that when each child is created, `self` is passed as the parent.
@@ -277,7 +265,7 @@ class DocumentLayout:
         self.children = []
 
     def layout(self):
-        child = BlockLayout(self.node, self)
+        child = BlockLayout(self.node, self, None)
         self.children.append(child)
         child.layout()
 ```
@@ -295,56 +283,87 @@ Size and position
 
 The layout tree is now made, but the size and position of each layout
 object is still left unset. Let's fix that. The general strategy is
-clear: each layout object computes its width, then lays out its
-children, and then computes its height.
+clear: each layout object computes its width and position, then lays
+out its children, and then computes its height.
 
-Besides width and height, we also need to position each element. This
-is trickier, because if you have several paragraphs, the position of
-the second depends on the height of the first. I'll use the rule that
-each element is positioned by its parent before its own `layout`
-method is called.
-
-Let's start in `BlockLayout`. For the width, elements are greedy:
-paragraph and headings and other things take up all the horizontal
-space they can. So it should use the parent's width:
+Let's start in `BlockLayout`. For the width, block layout objects are
+greedy: paragraph and headings and other things take up all the
+horizontal space they can. So they use the parent's width:
 
 ``` {.python}
 self.w = self.parent.w
 ```
 
-Then, each of the children need to be laid out. That means each child
-has to be positioned, and its `layout` method must be called:
+This also means that a block layout object's horizontal position is
+the same as its parent's:
+
+``` {.python}
+self.x = self.parent.x
+```
+
+The vertical position of a block layout object depends on whether it
+is its parent's first child or not. First children start at the top of
+the parent, later children start where the previous layout object
+ended:
+
+``` {.python}
+if self.previous:
+    self.y = self.previous.y + self.previous.h
+else:
+    self.y = self.parent.y
+```
+
+After the width and position is computed, we can lay out all the
+children of a block layout:
 
 ``` {.python indent=8}
-y = self.y
 for child in self.children:
-    child.x = self.x
-    child.y = y
     child.layout()
-    y += child.h
 ```
 
 Note that the call to the child's `layout` method not only asks it to
 compute its size, but also to its own children to the layout tree and
 recursively call `layout` on them.
 
-The height of an element must include all its children. Since the
-children's heights have already all been summed into `y`, we can just
-subtract its starting value to compute the height:
+Finally, once all the children are laid out, a height of the layout
+object can be computed:
 
 ``` {.python}
-self.h = y - self.y
+self.h = sum([child.h for child in self.children])
 ```
 
-That settles `BlockLayout`; let's now work on `InlineLayout`. Its `x`
-and `y` will be set by its parent, so its `layout` just needs to set
-`w` and `h`:
+Note how important the order is here. A block layout's width depends
+on the parent's width; so by symmetry the width must be computed
+before laying out the children. The position is the same: it has to be
+computed before recursing so it's already available when the children
+compute their own positions. But the height works the opposite way:
+the height of a block layout depends on the height of its children, so
+it must be computed after recursing, so that the heights of the
+children are available.
+
+This *dependency ordering* plays a really important role in
+understanding how layout works, especially as layout gets more
+complicated to support more features and faster speed. [Chapter
+10](reflow.md) will explore this topic more.
+
+That settles `BlockLayout`; let's now work on `InlineLayout`. Its `x`,
+`w`, and `y` are set the same way as for a `BlockLayout`, but its
+height is computed based on its *y*-cursor `cy` instead of the height
+of its children.
 
 ``` {.python}
 class InlineLayout:
     def layout(self):
+        self.x = self.parent.x
         self.w = self.parent.w
+
+        if self.previous:
+            self.y = self.previous.y + self.previous.h
+        else:
+            self.y = self.parent.y
+
         # ...
+
         self.h = self.cy - self.y
 ```
 
@@ -354,10 +373,10 @@ document always starts in the same place it's pretty simple:
 ``` {.python}
 class DocumentLayout:
     def layout(self):
-        self.w = WIDTH
         # ...
-        child.x = self.x = 0
-        child.y = self.y = 0
+        self.w = WIDTH - 2*HSTEP
+        self.x = HSTEP
+        self.y = VSTEP
         child.layout()
         self.h = child.h
 ```

--- a/src/lab5.py
+++ b/src/lab5.py
@@ -337,7 +337,7 @@ class DocumentLayout:
         child = BlockLayout(self.node, self, None)
         self.children.append(child)
 
-        self.w = WIDTH - 2 * HSTEP
+        self.w = WIDTH - 2*HSTEP
         self.x = HSTEP
         self.y = VSTEP
         child.layout()

--- a/src/lab5.py
+++ b/src/lab5.py
@@ -341,7 +341,7 @@ class DocumentLayout:
         self.x = HSTEP
         self.y = VSTEP
         child.layout()
-        self.h = child.h + 2*HSTEP
+        self.h = child.h + 2*VSTEP
 
     def draw(self, to):
         self.children[0].draw(to)

--- a/src/lab5.py
+++ b/src/lab5.py
@@ -341,7 +341,7 @@ class DocumentLayout:
         self.x = HSTEP
         self.y = VSTEP
         child.layout()
-        self.h = child.h
+        self.h = child.h + 2*HSTEP
 
     def draw(self, to):
         self.children[0].draw(to)

--- a/src/lab5.py
+++ b/src/lab5.py
@@ -54,143 +54,149 @@ def request(url):
     return headers, body
 
 class Text:
-    def __init__(self, text):
+    def __init__(self, text, parent):
         self.text = text
+        self.children = []
+        self.parent = parent
 
     def __repr__(self):
-        return "\"" + self.text.replace("\n", "\\n") + "\""
+        return repr(self.text)
 
-SELF_CLOSING_TAGS = [
-    "area", "base", "br", "col", "embed", "hr", "img", "input",
-    "link", "meta", "param", "source", "track", "wbr",
-]
+class Element:
+    def __init__(self, tag, attributes, parent):
+        self.tag = tag
+        self.attributes = attributes
+        self.children = []
+        self.parent = parent
 
-class Tag:
-    def __init__(self, text):
+    def __repr__(self):
+        attrs = [" " + k + "=\"" + v + "\"" for k, v  in self.attributes.items()]
+        return "<" + self.tag + "".join(attrs) + ">"
+
+def print_tree(node, indent=0):
+    print(" " * indent, node)
+    for child in node.children:
+        print_tree(child, indent + 2)
+
+class HTMLParser:
+    def __init__(self, body):
+        self.body = body
+        self.unfinished = []
+
+    def parse(self):
+        text = ""
+        in_tag = False
+        for c in self.body:
+            if c == "<":
+                in_tag = True
+                if text: self.add_text(text)
+                text = ""
+            elif c == ">":
+                in_tag = False
+                self.add_tag(text)
+                text = ""
+            else:
+                text += c
+        if not in_tag and text:
+            self.add_text(text)
+        return self.finish()
+
+    def get_attributes(self, text):
         parts = text.split()
-        self.tag = parts[0].lower()
-        self.attributes = {}
+        tag = parts[0].lower()
+        attributes = {}
         for attrpair in parts[1:]:
             if "=" in attrpair:
                 key, value = attrpair.split("=", 1)
                 if len(value) > 2 and value[0] in ["'", "\""]:
                     value = value[1:-1]
-                self.attributes[key.lower()] = value
+                attributes[key.lower()] = value
             else:
-                self.attributes[attrpair.lower()] = ""
+                attributes[attrpair.lower()] = ""
+        return tag, attributes
 
-    def __repr__(self):
-        return "<" + self.tag + ">"
+    def add_text(self, text):
+        if text.isspace(): return
+        self.implicit_tags(None)
+        parent = self.unfinished[-1]
+        node = Text(text, parent)
+        parent.children.append(node)
 
-def lex(body):
-    out = []
-    text = ""
-    in_tag = False
-    for c in body:
-        if c == "<":
-            in_tag = True
-            if text: out.append(Text(text))
-            text = ""
-        elif c == ">":
-            in_tag = False
-            out.append(Tag(text))
-            text = ""
-        else:
-            text += c
-    if not in_tag and text:
-        out.append(Text(text))
-    return out
+    SELF_CLOSING_TAGS = [
+        "area", "base", "br", "col", "embed", "hr", "img", "input",
+        "link", "meta", "param", "source", "track", "wbr",
+    ]
 
-class ElementNode:
-    def __init__(self, tag, parent, attributes):
-        self.tag = tag
-        self.parent = parent
-        self.attributes = attributes
-        self.children = []
+    def add_tag(self, tag):
+        tag, attributes = self.get_attributes(tag)
+        if tag.startswith("!"): return
+        self.implicit_tags(tag)
 
-    def __repr__(self):
-        return "<" + self.tag + ">"
-
-class TextNode:
-    def __init__(self, text, parent):
-        self.text = text
-        self.parent = parent
-        self.children = []
-
-    def __repr__(self):
-        return self.text.replace("\n", "\\n")
-        
-def parse(tokens):
-    currently_open = []
-    for tok in tokens:
-        parent = currently_open[-1] if currently_open else None
-
-        implicit_tags(tok, currently_open)
-        if isinstance(tok, Text):
-            if tok.text.isspace(): continue
-            node = TextNode(tok.text, parent)
+        if tag.startswith("/"):
+            if len(self.unfinished) == 1: return
+            node = self.unfinished.pop()
+            parent = self.unfinished[-1]
             parent.children.append(node)
-        elif tok.tag.startswith("/"):
-            node = currently_open.pop()
-            if not currently_open: return node
-            currently_open[-1].children.append(node)
-        elif tok.tag in SELF_CLOSING_TAGS:
-            node = ElementNode(tok.tag, tok.attributes, parent)
+        elif tag in self.SELF_CLOSING_TAGS:
+            parent = self.unfinished[-1]
+            node = Element(tag, attributes, parent)
             parent.children.append(node)
-        elif tok.tag.startswith("!"):
-            continue
         else:
-            node = ElementNode(tok.tag, parent, tok.attributes)
-            currently_open.append(node)
-    while currently_open:
-        node = currently_open.pop()
-        if not currently_open: return node
-        currently_open[-1].children.append(node)
+            parent = self.unfinished[-1] if self.unfinished else None
+            node = Element(tag, attributes, parent)
+            self.unfinished.append(node)
 
-HEAD_TAGS = [
-    "base", "basefont", "bgsound", "noscript",
-    "link", "meta", "title", "style", "script",
-]
+    HEAD_TAGS = [
+        "base", "basefont", "bgsound", "noscript",
+        "link", "meta", "title", "style", "script",
+    ]
+
+    def implicit_tags(self, tag):
+        while True:
+            open_tags = [node.tag for node in self.unfinished]
+            if open_tags == [] and tag != "html":
+                self.add_tag("html")
+            elif open_tags == ["html"] \
+                 and tag not in ["head", "body", "/html"]:
+                if tag in self.HEAD_TAGS:
+                    self.add_tag("head")
+                else:
+                    self.add_tag("body")
+            elif open_tags == ["html", "head"] and \
+                 tag not in ["/head"] + self.HEAD_TAGS:
+                self.add_tag("/head")
+            else:
+                break
+
+    def finish(self):
+        while self.unfinished:
+            node = self.unfinished.pop()
+            if not self.unfinished: return node
+            parent = self.unfinished[-1]
+            parent.children.append(node)
             
-def implicit_tags(tok, currently_open):
-    tag = tok.tag if isinstance(tok, Tag) else None
-    while True:
-        open_tags = [node.tag for node in currently_open]
-        if open_tags == [] and tag != "html":
-            currently_open.append(ElementNode("html", None, {}))
-        elif open_tags == ["html"] and tag not in ["head", "body", "/html"]:
-            if tag in HEAD_TAGS:
-                implicit = "head"
-            else:
-                implicit = "body"
-            parent = currently_open[-1]
-            currently_open.append(ElementNode(implicit, parent, {}))
-        elif open_tags == ["html", "head"] and tag not in ["/head"] + HEAD_TAGS:
-            node = currently_open.pop()
-            parent = currently_open[-1]
-            parent.children.append(node)
-        else:
-            break
 
 WIDTH, HEIGHT = 800, 600
 HSTEP, VSTEP = 13, 18
-LINEHEIGHT = 1.2
 
 SCROLL_STEP = 100
 
 class InlineLayout:
-    def __init__(self, node, parent):
+    def __init__(self, node, parent, previous):
         self.node = node
         self.parent = parent
+        self.previous = previous
         self.children = []
 
-        self.x = -1
-        self.y = -1
-        self.w = -1
-        self.h = -1
-
     def layout(self):
+        self.x = self.parent.x
         self.w = self.parent.w
+
+        if self.previous:
+            self.y = self.previous.y + self.previous.h
+        else:
+            self.y = self.parent.y
+
         self.display_list = []
 
         self.cx = self.x
@@ -206,7 +212,7 @@ class InlineLayout:
         self.h = self.cy - self.y
 
     def recurse(self, node):
-        if isinstance(node, TextNode):
+        if isinstance(node, Text):
             self.text(node.text)
         else:
             self.open(node.tag)
@@ -277,42 +283,41 @@ INLINE_ELEMENTS = [
 ]
 
 class BlockLayout:
-    def __init__(self, node, parent):
+    def __init__(self, node, parent, previous):
         self.node = node
         self.parent = parent
+        self.previous = previous
         self.children = []
-
-        self.x = -1
-        self.y = -1
-        self.w = -1
-        self.h = -1
 
     def has_block_children(self):
         for child in self.node.children:
-            if isinstance(child, TextNode):
-                if not child.text.isspace():
-                    return False
+            if isinstance(child, Text):
+                return False
             elif child.tag in INLINE_ELEMENTS:
                 return False
         return True
 
     def layout(self):
-        # block layout here
         if self.has_block_children():
+            previous = None
             for child in self.node.children:
-                if isinstance(child, TextNode): continue
-                self.children.append(BlockLayout(child, self))
+                previous = BlockLayout(child, self, previous)
+                self.children.append(previous)
         else:
-            self.children.append(InlineLayout(self.node, self))
+            self.children.append(InlineLayout(self.node, self, None))
 
+        self.x = self.parent.x
         self.w = self.parent.w
-        y = self.y
+
+        if self.previous:
+            self.y = self.previous.y + self.previous.h
+        else:
+            self.y = self.parent.y
+
         for child in self.children:
-            child.x = self.x
-            child.y = y
             child.layout()
-            y += child.h
-        self.h = y - self.y
+
+        self.h = sum([child.h for child in self.children])
 
     def draw(self, to):
         if self.node.tag == "pre":
@@ -325,20 +330,16 @@ class DocumentLayout:
     def __init__(self, node):
         self.node = node
         self.parent = None
+        self.previous = None
         self.children = []
 
-        self.x = -1
-        self.y = -1
-        self.w = -1
-        self.h = -1
-
     def layout(self):
-        self.w = WIDTH
-        child = BlockLayout(self.node, self)
+        child = BlockLayout(self.node, self, None)
         self.children.append(child)
 
-        child.x = self.x = 0
-        child.y = self.y = 0
+        self.w = WIDTH - 2 * HSTEP
+        self.x = HSTEP
+        self.y = VSTEP
         child.layout()
         self.h = child.h
 
@@ -392,7 +393,8 @@ class Browser:
         self.window.bind("<Down>", self.scrolldown)
         self.display_list = []
 
-    def layout(self, tree):
+    def layout(self, body):
+        tree = HTMLParser(body).parse()
         document = DocumentLayout(tree)
         document.layout()
         self.display_list = []
@@ -410,13 +412,12 @@ class Browser:
     def scrolldown(self, e):
         self.scroll = self.scroll + SCROLL_STEP
         self.scroll = min(self.scroll, self.max_y)
-        self.scroll = max(0, self.scroll))
+        self.scroll = max(0, self.scroll)
         self.render()
 
 if __name__ == "__main__":
     import sys
     headers, body = request(sys.argv[1])
-    nodes = parse(lex(body))
     browser = Browser()
-    browser.layout(nodes)
+    browser.layout(body)
     tkinter.mainloop()


### PR DESCRIPTION
This changes how the layout tree is linked and the protocol for computing layout. Basically, in addition to a parent and a list of
children, each layout object now also has a pointer to its previous sibling. That way, to compute its Y-position, a layout object can reference its previous sibling's Y-position and height.

This might seem more complex than having the parent keep track of a vertical cursor for children, but the advantage of this approach is that computing the layout of each layout object is totally self-contained to a single `layout` function, instead of
responsibilities being split between that node's and its parent's `layout` functions. It also means that the recursive calls to
`layout` are purely that---calling `layout` on each child---instead of being interlaced with code that tracks a vertical cursor.

I've also added a paragraph that talks about dependencies and why the order is so important—this is easier to discuss now that it's purely an ordering problem within a single function. That could set us up to talk about dependencies better in the reflow chapter.