### PR TITLE
Rename Browser.layout to Browser.load

### DIFF
--- a/book/html.md
+++ b/book/html.md
@@ -570,7 +570,8 @@ the node tree, like this:
 
 ``` {.python}
 class Browser:
-    def layout(self, body):
+    def load(self, url):
+        headers, body = request(url)
         tree = HTMLParser(body).parse()
         self.display_list = Layout(tree).display_list
         self.render()

--- a/book/http.md
+++ b/book/http.md
@@ -479,19 +479,26 @@ def show(body):
     # ...
 ```
 
-We can now string together `request` and `show`:
+We can now load a web page just by stringing together `request` and
+`show`:
+
+``` {.python}
+def load(url):
+    headers, body = request(url)
+    show(body)
+```
+
+Add the following code to run `load` from the command line:
 
 ``` {.python}
 if __name__ == "__main__":
     import sys
-    headers, body = request(sys.argv[1])
-    show(body)
+    load(sys.argv[1])
 ```
 
-The first line here is Python's version of a `main` function. The code
-reads the first argument (`sys.argv[1]`) from the command line using
-the `sys` module. That first argument is used as the URL. Try running
-this code on the URL `http://example.org/`:
+This is Python's version of a `main` function---it reads the first
+argument (`sys.argv[1]`) from the command line and uses it as a URL.
+Try running this code on the URL `http://example.org/`:
 
     python3 browser.py http://example.org/
 

--- a/book/layout.md
+++ b/book/layout.md
@@ -601,7 +601,7 @@ past the bottom of the page. In `load`, store the height in a
 
 ``` {.python}
 class Browser:
-    def load(self, body):
+    def load(self, url):
         # ...
         self.max_y = document.h - HEIGHT
 ```

--- a/book/layout.md
+++ b/book/layout.md
@@ -398,12 +398,13 @@ Using tree-based layout
 =======================
 
 With tree-based layout implemented, let's use it in the browser
-itself, in its `layout` method. First, we need to create the layout
-tree and lay it out:
+itself, in the `load` method. First, we need to create the layout tree
+and lay it out:
 
 ``` {.python}
 class Browser:
-    def layout(self, body):
+    def load(self, url):
+        headers, body = request(url)
         tree = HTMLParser(body).parse()
         document = DocumentLayout(tree)
         document.layout()
@@ -446,12 +447,12 @@ class InlineLayout:
         to.extend(self.display_list)
 ```
 
-Now the browser can use draw to collect its own `display_list`
+Now the browser can use `draw` to collect its own `display_list`
 variable:
 
 ``` {.python}
 class Browser:
-    def layout(self, body):
+    def load(self, url):
         # ...
         self.display_list = []
         document.draw(self.display_list)
@@ -595,13 +596,14 @@ def render(self):
 
 We not only have access to the height of any element, but also of the
 whole page. The browser can use that to stop the user from scrolling
-past the bottom of the page. In `layout`, store the height in a
+past the bottom of the page. In `load`, store the height in a
 `max_y` variable:
 
 ``` {.python}
-def layout(self, body):
-    # ...
-    self.max_y = document.h - HEIGHT
+class Browser:
+    def load(self, body):
+        # ...
+        self.max_y = document.h - HEIGHT
 ```
 
 Then, when the user scrolls down, don't let them scroll past the

--- a/book/text.md
+++ b/book/text.md
@@ -375,15 +375,18 @@ Note that `Text` and `Tag` are asymmetric: `lex` avoids empty
 `Tag` object represents the HTML code `<>`, while an empty `Text`
 object with empty text represents no content at all.
 
-Now `layout` has access not just to the text of the page, but also the
-tags in it. So `layout` must loop over tokens, not text:
+Since we've modified `lex` we are now passing `layout` not just the
+text of the page, but also the tags in it. So `layout` must loop over
+tokens, not text:
 
 ``` {.python expected=False}
-def layout(tokens):
+def layout(self, tokens):
+    # ...
     for tok in tokens:
         if isinstance(tok, Text):
             for word in tok.text.split():
                 # ...
+    # ...
 ```
 
 `layout` can also examine tag tokens to change font when directed by
@@ -504,13 +507,16 @@ def text(self, text):
         # ...
 ```
 
-Now that everything has moved out of `Browser`'s old `layout`
+Now that everything has moved out of `Browser`'s old `load`
 function, it can be replaced with calls into `Layout`:
 
 ``` {.python}
-def layout(self, tokens):
-    self.display_list = Layout(tokens).display_list
-    self.render()
+class Browser:
+    def load(self, url):
+        headers, body = request(url)
+        tokens = lex(body)
+        self.display_list = Layout(tokens).display_list
+        self.render()
 ```
 
 When you do big refactors like this, it's important to work

--- a/src/lab1.py
+++ b/src/lab1.py
@@ -61,7 +61,10 @@ def show(body):
         elif not in_angle:
             print(c, end="")
 
+def load(url):
+    headers, body = request(url)
+    show(body)
+
 if __name__ == "__main__":
     import sys
-    headers, body = request(sys.argv[1])
-    show(body)
+    load(sys.argv[1])

--- a/src/lab2.py
+++ b/src/lab2.py
@@ -69,6 +69,17 @@ HSTEP, VSTEP = 13, 18
 
 SCROLL_STEP = 100
 
+def layout(self, text):
+    display_list = []
+    x, y = HSTEP, VSTEP
+    for c in text:
+        display_list.append((x, y, c))
+        x += HSTEP
+        if x >= WIDTH - HSTEP:
+            y += VSTEP
+            x = HSTEP
+    return display_list
+
 class Browser:
     def __init__(self):
         self.window = tkinter.Tk()
@@ -82,15 +93,10 @@ class Browser:
         self.scroll = 0
         self.window.bind("<Down>", self.scrolldown)
 
-    def layout(self, text):
-        self.display_list = []
-        x, y = HSTEP, VSTEP
-        for c in text:
-            self.display_list.append((x, y, c))
-            x += HSTEP
-            if x >= WIDTH - HSTEP:
-                y += VSTEP
-                x = HSTEP
+    def load(self, url):
+        headers, body = request(url)
+        text = lex(body)
+        self.display_list = layout(text)
         self.render()
 
     def render(self):
@@ -106,8 +112,5 @@ class Browser:
 
 if __name__ == "__main__":
     import sys
-    headers, body = request(sys.argv[1])
-    text = lex(body)
-    browser = Browser()
-    browser.layout(text)
+    Browser().load(sys.argv[1])
     tkinter.mainloop()

--- a/src/lab3.py
+++ b/src/lab3.py
@@ -166,7 +166,9 @@ class Browser:
         self.window.bind("<Down>", self.scrolldown)
         self.display_list = []
 
-    def layout(self, tokens):
+    def load(self, url):
+        headers, body = request(url)
+        tokens = lex(body)
         self.display_list = Layout(tokens).display_list
         self.render()
 
@@ -183,8 +185,5 @@ class Browser:
 
 if __name__ == "__main__":
     import sys
-    headers, body = request(sys.argv[1])
-    text = lex(body)
-    browser = Browser()
-    browser.layout(text)
+    Browser().load(sys.argv[1])
     tkinter.mainloop()

--- a/src/lab4.py
+++ b/src/lab4.py
@@ -267,7 +267,8 @@ class Browser:
         self.window.bind("<Down>", self.scrolldown)
         self.display_list = []
 
-    def layout(self, body):
+    def load(self, url):
+        headers, body = request(url)
         tree = HTMLParser(body).parse()
         self.display_list = Layout(tree).display_list
         self.render()
@@ -285,7 +286,5 @@ class Browser:
 
 if __name__ == "__main__":
     import sys
-    headers, body = request(sys.argv[1])
-    browser = Browser()
-    browser.layout(body)
+    Browser().load(sys.argv[1])
     tkinter.mainloop()

--- a/src/lab5.py
+++ b/src/lab5.py
@@ -393,7 +393,8 @@ class Browser:
         self.window.bind("<Down>", self.scrolldown)
         self.display_list = []
 
-    def layout(self, body):
+    def load(self, url):
+        headers, body = request(url)
         tree = HTMLParser(body).parse()
         document = DocumentLayout(tree)
         document.layout()
@@ -417,7 +418,5 @@ class Browser:
 
 if __name__ == "__main__":
     import sys
-    headers, body = request(sys.argv[1])
-    browser = Browser()
-    browser.layout(body)
+    Browser().load(sys.argv[1])
     tkinter.mainloop()


### PR DESCRIPTION
This forward parts Ch6 (Styles) needs a `load` method to download both content and stylesheets. But as an added bonus, renaming this method also makes sure that there are never two `layout` methods (on `Browser` and on `SomethingLayout`) that do different things.