### PR TITLE
More reasonable and restrained cuts to Section 3 of the introduction

### DIFF
--- a/book/browsersandweb.md
+++ b/book/browsersandweb.md
@@ -162,98 +162,88 @@ been far from it in my studies or work.
 
 [^chris]: This is Chris speaking!
 
-[^bbs]: For me, this was mostly using
-[BBS](https://en.wikipedia.org/wiki/Bulletin_board_system) systems over a dialup
-modem connection. A BBS is not all that different in concept from a browser if
-you look at it from the point of view of “window into dynamic content created
-somewhere else on the Internet”.
+[^bbs]: For me, [BBS](https://en.wikipedia.org/wiki/Bulletin_board_system)
+systems over a dialup modem connection. A BBS is not all that different from a
+browser if you think of it as a window into dynamic content created somewhere
+else on the Internet.
 
-In my freshman year at college, I attended a presentation at the university by a
-RedHat salesman. The presentation was of course aimed at selling RedHat Linux,
-and probably included statements like Linux being the operating system of the
-future, or the always-popular speculation about the “year of the Linux desktop.”
-However, when asked about challenges RedHat faced, the salesman mentioned not
-Linux but _the web_. He said something like “someone needs to make a good
-browser for Linux. _It’s hard to be competitive without a good
-browser”_[^netscape-linux]_._ Even back then, in the very first year or so of
-the web, the browser was already becoming an absolutely necessary component of
-every computer. He even threw out a challenge: “how hard could it be to build a
-better browser?” Indeed, how hard could it be? What makes it so hard? That
-question stuck with me for a long time.[^meantime-linux]
+In my freshman year at college, I attended a presentation by a RedHat salesman.
+The presentation was of course aimed at selling RedHat Linux, probably calling
+it the "operating system of the future" and speculating about the "year of the
+Linux desktop". But when asked about challenges RedHat faced, the salesman
+mentioned not Linux but _the web_: he said that someone "needs to make a good
+browser for Linux".[^netscape-linux] Even back then, in the very first year or
+so of the web, the browser was already a necessary component of every computer.
+He even threw out a challenge: "how hard could it be to build a better browser?"
+Indeed, how hard could it be? What makes it so hard? That question stuck with me
+for a long time.[^meantime-linux]
 
 [^netscape-linux]: Netscape Navigator was available for Linux at that time, but
 it wasn’t viewed as especially fast or featureful compared to its implementation
 on other operating systems.
 
+[^meantime-linux]: Meanwhile, the "better Linux browser than Netscape" took a
+long time to appear....
 
-[^meantime-linux]: Meanwhile, the “better Linux browser than Netscape” seemed to
-take quite a long time to appear....
+How hard indeed! After seven years in the trenches working on Chrome, I now know
+the answer to his question: building a browser is both easy and incredibly hard,
+both intentional and accidental, both planned and organic, both simple and
+unimaginably complex. Everywhere you look, you see the evolution and history of
+the web wrapped up in one codebase.
 
-How hard indeed! After seven years in the trenches working on a browser
-(Chrome), I now know the answer to his question: building such a browser is
-both easy and incredibly hard, intentional and accidental, planned and organic,
-simple and unimaginably complex. And everywhere you look, you can see the
-evolution and history of the web all wrapped up in one codebase.
+As you’ll see in this book, it’s surprisingly easy to write a very simple
+browser, one that can despite its simplicity display interesting-looking web
+pages, and support many interesting behaviors. This starting point---that it’s
+easy to write and support basic web pages---encapsulates the (intentionally!)
+easy-to-implement core of the web architecture.[^prog-enhance] Sometime during
+my first few months of working on Chrome, I came across the code implementing
+the [`<br>`][br-tag] tag---look at that, the good-old `<br>` tag that I’ve used
+many times to insert newlines into web pages! And the implementation turns out
+to be barely any code at all, both in Chrome and in this book's simple browser.
 
-As you’ll see when reading this book, it’s surprisingly easy to write a very
-simple browser, one that can despite its simplicity display interesting-looking
-web pages, and can even more-or-less correctly display many real ones, including
-this book. This starting point---it’s easy enough to implement (and write) web
-pages with the basics---encapsulates the (intentionally!) easy-to-implement core
-of the web architecture, what you might call the _base level_ of [progressive
-enhancement](https://en.wikipedia.org/wiki/Progressive_enhancement). I saw this
-in the relative simplicity of individual features of Chrome---for example,
-sometime during my first few months of working on Chrome, I came across the code
-implementing the
-[`<br>`](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/br) tag. Look
-at that, the good-old `<br>` tag that I’ve used many times as a convenient hack
-to insert newlines in the text of my web pages! And as it turns out, there
-really isn’t much code at all to implement this tag, either in Chrome or the
-simple browser you’ll build.
+[^prog-enhance]: You might relate this to the history of the web and the idea of
+    [progressive enhancement][prog-enhance].
+[prog-enhance]: https://en.wikipedia.org/wiki/Progressive_enhancement
+[br-tag]: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/br
 
-On the other hand, to make a browser that has all the features, performance,
-security and reliability of today’s top browsers---well that is a whole lot of
-work; _thousands_ of person-years of effort went into what you see today. On top
-of that, but keeping a browser competitive is a lot of work: not only is there
-an inherent cost to maintaining such large codebases, but there is constant
-pressure to do more---add more features, continually improve performance to beat
-the competition, and in general keep up with everything going on in what we now
-call the “web ecosystem”---the millions of developers, billions of users, and
-all the businesses and economies that build on the web. There are tens of
-thousands of unfixed bugs in every browser, representing all the ways that bugs
-can appear with the smallest of mistakes, through the myriad of ways to mix and
-match features. There is the extreme complexity of trying to understand the
-complicated set of optimizations deemed necessary to squeeze out the last bit of
-performance from the system. And there is the painstaking, but necessary, work
-to continuously refactor the code to reduce its complexity through the
+On the other hand, a browser with all the features, performance, security, and
+reliability of today’s top browsers---_that_ is a whole lot of work. _Thousands_
+of person-years of effort went into the browsers you use today. And keeping a
+browser competitive is a lot of work as well: not only is there an inherent cost
+to maintaining large codebases, there is also constant pressure to do more---to
+add more features, improve performance, and keep up with the "web
+ecosystem"---the thousands of businesses, millions of developers, and billions
+of users that use the web. Every browser has thousands of unfixed bugs, from the
+smallest of mistakes to the myriad of ways to mix up and mis-match features.
+Every browser has a complicated set of optimizations to squeeze out that last
+bit of performance. And every browser has painstaking, but necessary, work to
+continuously refactor the code to reduce its complexity through the
 careful[^browsers-abstraction-hard] introduction of modularization and
 abstraction.
 
 [^browsers-abstraction-hard]: Browsers are so performance-sensitive in many
-places that merely the introduction of an abstraction - and the typical ensuing
-function call or branching overhead---can cause an unacceptable performance
-cost.
+places that merely the introduction of an abstraction---the function call or
+branching overhead---can cause an unacceptable performance cost.
 
-Working on such a codebase is often daunting. For one thing, there is an
-immense history to each browser. It’s not uncommon to find lines of code last
+Working on such a codebase is often daunting. For one thing, there is the
+weighty history of each browser. It’s not uncommon to find lines of code last
 touched 15 years ago by someone who you’ve never met; or even after years of
-working discover files and code that you didn’t even know existed; or see 
-lines of code that don’t look necessary, and all tests pass without them. If I
-want to know what that 15-year-old code does, how can I do it? Does that code
-I just discovered matter at all? Can I just delete those lines of code that
-don’t seem necessary?
+working discover files and code that you didn’t even know existed; or see lines
+of code that don’t look necessary, yet seem to do something important. If I want
+to know what that 15-year-old code does, how can I do it? Does that code I just
+discovered matter at all? Can I delete those lines of code, or are they there
+for a reason?
 
-These kinds of quandaries come up all the time when working on a browser - in
-fact they are common to all complex codebases. What makes a browser different is
-that there is often an _urgency to fix them_. Browsers are nearly as old as any
-“legacy” codebase, but are _not_ legacy (meaning deprecated or half-deprecated,
-and scheduled to be replaced by some new codebase sometime soon) at all---on the
-contrary, they are vital to the world’s economy. For this reason, and the
-infeasibility of rewriting, browser engineers are forced[^forced-negative] to
-fix and improve rather than replace.
+These kinds of quandaries are common to all complex codebases. But what makes a
+browser different is that there is often an _urgency to fix them_. Browsers are
+nearly as old as any “legacy” codebase, but are _not_ legacy, not abondoned or
+half-deprecated, not slated for replacement. On the contrary, they are vital to
+the world’s economy. Browser engineers are forced[^forced-negative] to fix and
+improve rather than abaondon and replace.
 
-[^forced-negative]: I say "forced", which has a negative connotation, but it’s
-more of an iterative & continuous process of improvement.
+[^forced-negative]: I don't intend the negative connotation. It’s because
+browsers are dynamic important that we browser developers can afford an
+iterative & continuous process of improvement.
 
 It’s not just urgency though---understanding the cumulative answers to these
 small questions yields true insights into how computing actually works, and

--- a/book/browsersandweb.md
+++ b/book/browsersandweb.md
@@ -60,91 +60,90 @@ and fun journey. That's what this book is about.
 Explaining the black box
 ========================
 
-As you may already know from making websites, the core implementation components
-of the web are approachable enough - an HTML & CSS-based document model, HTTP,
-hyperlinks, and JavaScript. Most people can learn easily enough how to make simple
-HTML pages; programming abilities are not required. But how does the browser
-actually do its job of rendering that HTML? As it turns out, not many people
-who don’t work on browsers actually know in much detail, even trained software
-developers![^software-developers]
+HTML, CSS, HTTP, hyperlinks, and JavaScript---the core of the web---are
+approachaable enough, and if you've made a website before[^recommended] you've
+seen that programming ability is not required. But not many people---not even
+professional software developers---know much about how a browser renders web
+pages![^software-developers]
 
-[^software-developers]: I usually prefer the word “engineer”, but on the web
-it’s much more common to use the word “developer”, or more specifically “web
-developer”, so I’ll use that term in this book. An additional advantage of using
-“developer” is that it’s not necessary to be a trained software engineer or
-computer scientist to build websites; on the contrary, one goal of the web has
-always been  to make its use accessible to all people, not just experts. In fact
-many websites are in large part built by those trained in other disciplines;
-“web developer” is more inclusive of these additional, critical roles.
+[^recommended]: If you haven't, I recommend MDN's [Learn Web
+    Development][learn-web] series, especially the [Getting
+    Started][learn-basics] guide. This book will be easier to read if
+    you're familiar with the core technologies.
+    
+[learn-web]: https://developer.mozilla.org/en-US/docs/Learn
+[learn-basics]: https://developer.mozilla.org/en-US/docs/Learn/Getting_started_with_the_web
 
-Most of us developers treat the browser as a black box, one that is either
-magical or frustrating (depending on whether it is working correctly or not!).
-After all, HTML & CSS _are_ black boxes, or more precisely declarative APIs -
-ones in which one specifies _what_ outcome is desired, as opposed to _how_ to
-achieve that outcome. It’s the _browser itself_ that is responsible for figuring
-out the how. Not only are website developers encouraged not to say how exactly
-the pixels on the screen are generated, in most cases there _is no feasible way_
-for developers to draw their website’s pixels “on their own”.
+[^software-developers]: I usually prefer “engineer”---hence the title of this
+book---but “developer” or “web developer” is much more common on the web. One
+important reason is that anyone can build a website---not just trained software
+engineers and computer scientists. “Web developer” is more inclusive of
+additional, critical roles like designers, authors, editors, or photographers.
 
-In that sense, they also lose control and some amount of agency---when those
-pixels are wrong, they cannot directly fix them.[^loss-of-control] However, this
-loss of control comes with powerful upsides, such as: it’s much easier to make
-and deploy content on the web without having to implement many of the details;
-that content is instantly (magically!) available on every computing device in
-existence; and the content is likely to be accessible in the future, avoiding
-(for the most part) the inevitable obsolescence of most software.
+As a black box, the browser is either magical or frustrating, depending on
+whether it is working correctly or not! And HTML & CSS are meant to be black
+boxes---declarative APIs---that one specifies _what_ outcome to achieve, as
+opposed to _how_ to achieve it. The _browser itself_ is responsible for figuring
+out the "how". Web developers don't, and mostly can't, draw their website’s
+pixels “on their own”.
+
+There are philosophical reasons for this unusual design. Yes, developers lose
+some control and agency---when those pixels are wrong, developers cannot fix
+them directly.[^loss-of-control] But they gain the ability to deploy content on
+the web without worrying about the details, to make that content instantly
+available on almost every computing device in existence, and to keep it
+accessible in the future, mostly avoiding the inevitable obsolescence of most
+software.
 
 [^loss-of-control]: Loss of control not necessarily specific to the web - much
 of computing these days involves relying on mountains of other peoples’ code.
 
+Behind the philosophy lies a web browser's implementations of [inversion of
+control][inversion], [constraint programming][contraints], and [declarative
+programming][declarative]. The web _inverts control_, with an intermediary---the
+browser---handling most of the rendering, and the web developer specifying
+parameters and content to this intermediary. Further, these parameters usually
+take the form of _constraints_ over relative sizes and positions instead of
+specifying their values directly.[^constriants] It's the browser's job to solve
+the constraints or to pick which ones to break. The same idea applies for
+actions: web pages mostly require _that_ actions take place without specifying
+_when_ they do. This _declarative_ style means that from the point of view of a
+developer, changes "apply immediately", but under the hood, the browser can be
+[lazy][lazy] and delay applying the changes until they become externally
+visible, either due to subsequence API calls or because the page has to be
+displayed to the user.[^style-calculation]
 
-This “what, not how” aspect of the web has multiple aspects, including
-[inversion of control](https://en.wikipedia.org/wiki/Inversion_of_control),
-[constraint
-programming](https://en.wikipedia.org/wiki/Constraint_programming#:~:text=Constraint%20programming%20(CP)%20is%20a,a%20set%20of%20decision%20variables.),
-and [declarative
-programming](https://en.wikipedia.org/wiki/Declarative_programming). _Inversion
-of control_ is a way of delegating most details of rendering to a framework (in
-this case, the browser), and only specifying the parameters or extension points
-to the framework within the application itself. For example, in HTML there are
-many built-in [form control
-elements](https://developer.mozilla.org/en-US/docs/Learn/Forms/Basic_native_form_controls)
-that take care of the various ways the user of a website can provide input.  The
-developer need only specify parameters such as button names, sizing, and
-look-and-feel, or JavaScript extension points to handle form submission to the
-server. The rest of the implementation is taken care of by the browser.
-_Constraint programming_ is an approach for numerical-oriented algorithms that
-specifies constraints involving limits, relative proportions and sizes of
-numerical variables, plus an optimization function; the algorithm to find the
-optimal solution is the job of someone else (the browser in our case). This
-concept appears in the web in page layout, which depends on many numerical
-factors such as font and browser window sizes, desired position and size of
-boxes, and tabular arrangement of widgets[^layout-optimization-function].
+[inversion]: https://en.wikipedia.org/wiki/Inversion_of_control
+[contraints]: https://en.wikipedia.org/wiki/Constraint_programming#:~:text=Constraint%20programming%20(CP)%20is%20a,a%20set%20of%20decision%20variables.
+[declarative]: https://en.wikipedia.org/wiki/Declarative_programming
+[lazy]: https://en.wikipedia.org/wiki/Lazy_evaluation
 
-[^layout-optimization-function]: A fun question to consider: what might be the
-“optimization function” of layout?
+[^forms]: As just one examples, in HTML there are many built-in [form control
+elements][forms] that take care of the various ways the user of a website can
+provide input. The developer need only specify parameters such as button names,
+sizing, and look-and-feel, or JavaScript extension points to handle form
+submission to the server. The rest of the implementation is taken care of by the
+browser.
 
-Even after answering the _what_ and the _how_, there is still the _declarative
-programming_ aspect of the web---_when_ various computations happen. For
-example, when exactly does style (re-)calculation[^style-calculation] happen?
-From the point of view of the developer, styles "apply immediately”, meaning
-that any subsequent API the developer might call gives an answer that takes the
-new style into account. But what if the developer never calls such an API---does
-the work ever need to be done? Clearly 	it does if it affects what the browser’s
-user experiences, such as what pixels are drawn on the screen, but not
-otherwise.
+[forms]: https://developer.mozilla.org/en-US/docs/Learn/Forms/Basic_native_form_controls
 
-It is to the advantage of the browser to not perform style re-calculation unless
-necessary, since it can avoid redundant work in situations such as the style
-inputs changing twice in quick succession. For this reason, browsers are as
-[lazy](https://en.wikipedia.org/wiki/Lazy_evaluation) as possible about doing
-work, but not so lazy as to unnecessarily delay pixels updating on the screen.
-It turns out that a whole lot of the complexity and cleverness of real-world
-browsers involves maximally exploiting the performance-enhancing opportunities
-afforded by declarative programming.
+[^constraints]: Constraint programming is clearest during web page layout, where
+font and window sizes, desired positions and sizes, and the relative arrangement
+of widgets is rarely specified directly. A fun question to consider: what does
+the browser "optimize for" when computing a layout?
 
-[^style-calculation]: Style calculation is the process of figuring out, based on
-the current CSS and HTML, which styles apply to which elements.
+[^style-calculation]: For example, when exactly the browser compute which CSS
+styles apply to which HTML element, for example after a web page changes those
+styles? The change is visible to all subsequence API calls, so in that sense it
+applies "immediately". But it is better for the browser to delay style
+re-calculation, avoiding redundant work if styles change twice in quick
+succession. Maximally exploiting the opportunities afforded by declarative
+programming makes real-world browsers very complex.
+
+The up shot of all this is that a browser is a pretty unusual piece of software,
+with unique challenges, interesting algorithms, and clever optimizations
+invented just for this domain. That makes browsers worth studying for the pure
+pleasure of it---even leaving aside their importance!
 
 The browser and me
 ==================

--- a/book/browsersandweb.md
+++ b/book/browsersandweb.md
@@ -188,7 +188,7 @@ long time to appear....
 How hard indeed! After seven years in the trenches working on Chrome, I now know
 the answer to his question: building a browser is both easy and incredibly hard,
 both intentional and accidental, both planned and organic, both simple and
-unimaginably complex. Everywhere you look, you see the evolution and history of
+unimaginably complex. And everywhere you look, you see the evolution and history of
 the web wrapped up in one codebase.
 
 As you’ll see in this book, it’s surprisingly easy to write a very simple
@@ -242,7 +242,7 @@ the world’s economy. Browser engineers are forced[^forced-negative] to fix and
 improve rather than abaondon and replace.
 
 [^forced-negative]: I don't intend the negative connotation. It’s because
-browsers are dynamic important that we browser developers can afford an
+browsers are so important that we browser developers can afford an
 iterative & continuous process of improvement.
 
 It’s not just urgency though---understanding the cumulative answers to these


### PR DESCRIPTION
This section is pretty powerful so I didn't want to make any big changes that could hurt that. But in a few places I thought it could be shortened.

One big question I have about this section is the last paragraph. I think this paragraph is what my kind of dopey trailer in #55 was trying to be. What do you think of moving this section ("The browser and me") before the previous one ("Explaining the black box")? And then using the last paragraph of this section as the last paragraph of "Explaining the black box"?