### PR TITLE
Refactor `has_block_children` in the Layout chapter

### DIFF
--- a/book/layout.md
+++ b/book/layout.md
@@ -201,7 +201,7 @@ When creating child layout objects, the main question is whether each
 child should be a `BlockLayout` or an `InlineLayout`. Basically,
 elements that just contains text, or maybe formatted text, should have
 an `InlineLayout`, but containers like `<div>` or `<header>` should
-have a `BlockLayout`. But what happens if an elements contains both
+have a `BlockLayout`. But what happens if an element contains both
 text and something like a `<div>`?
 
 In real browsers, a somewhat complicated mechanism known as [anonymous
@@ -227,7 +227,7 @@ INLINE_ELEMENTS = [
 
 To determine whether an element has an `InlineLayout` or a
 `BlockLayout` we compare its children against that list. Let's add a
-top-level `layout_mode` function that function looks through the
+top-level `layout_mode` function that looks through the
 children of a node and categorizes them as either "text", including
 formatting tags, or containers:
 

--- a/book/layout.md
+++ b/book/layout.md
@@ -57,7 +57,7 @@ Second: the layout tree. Layout modes can nest: a web page can have an
 `<html>` in block layout that contains a `<body>` in block layout that
 contains a `<p>` in inline layout. So tree-based layout starts by
 traversing the HTML tree to build a _layout tree_, where each layout
-object in the tree is one of the layout modes.
+object in the tree is associated with one of the layout modes.
 
 Layout is very complex, so in this chapter the tree will have a very
 simple structure: it'll contain block layout objects at each branch,
@@ -82,7 +82,7 @@ while its *height* is based on its *children*'s height:
     from child to parent.](/im/layout-order.png)
 
 This suggests a step-by-step approach to layout. First, an element
-compute its position and width, based on its parent. Then it lays out
+computes its position and width, based on its parent. Then it lays out
 its children. Finally, with the children's heights computed, the
 element's height is calculated.
 
@@ -206,12 +206,11 @@ have a `BlockLayout`.
 
 What happens if an element contains both text and something like a
 `<div>`? In some sense, this is an error on the part of the web
-developer. Just like with implicit tags in [Chapter 4][html.md],
+developer. And just like with implicit tags in [Chapter 4][html.md],
 browsers use a repair mechanism to make sense of the situation. In
-real browsers, the mechanism is known as [anonymous block
-boxes][anon-block] is used, but in our toy browser we'll implement
-something a little simpler. We'll start by listing the elements used
-for formatting text:
+real browsers, "[anonymous block boxes][anon-block]" are used, but in
+our toy browser we'll implement something a little simpler. Let's
+start by listing the elements used for formatting text:
 
 [anon-block]: https://developer.mozilla.org/en-US/docs/Web/CSS/Visual_formatting_model#anonymous_boxes
 

--- a/book/layout.md
+++ b/book/layout.md
@@ -201,18 +201,16 @@ When creating child layout objects, the main question is whether each
 child should be a `BlockLayout` or an `InlineLayout`. Basically,
 elements that just contains text, or maybe formatted text, should have
 an `InlineLayout`, but containers like `<div>` or `<header>` should
-have a `BlockLayout`. But what happens if an element contains both
-text and something like a `<div>`?
+have a `BlockLayout`.
 
-In real browsers, a somewhat complicated mechanism known as [anonymous
-block boxes][anon-block] is used, but in our toy browser we'll
-implement something a little simpler.[^how-anon] We'll start by
-listing the elements used for formatting text:
-
-[^how-anon]: Anonymous block boxes handle cases like an element
-that contains text, formatted text, and also a container. You can
-think of this as a repair mechanism similar to the implicit tags in
-[Chapter 4][html.md].
+What happens if an element contains both text and something like a
+`<div>`? In some sense, this is an error on the part of the web
+developer. Just like with implicit tags in [Chapter 4][html.md],
+browsers use a repair mechanism to make sense of the situation. In
+real browsers, the mechanism is known as [anonymous block
+boxes][anon-block] is used, but in our toy browser we'll implement
+something a little simpler. We'll start by listing the elements used
+for formatting text:
 
 [anon-block]: https://developer.mozilla.org/en-US/docs/Web/CSS/Visual_formatting_model#anonymous_boxes
 

--- a/book/layout.md
+++ b/book/layout.md
@@ -206,11 +206,15 @@ text and something like a `<div>`?
 
 In real browsers, a somewhat complicated mechanism known as [anonymous
 block boxes][anon-block] is used, but in our toy browser we'll
-implement something a little simpler. We'll start with a list of
-elements used for formatting text, which should be inside an
-`InlineLayout`:
+implement something a little simpler.[^how-anon] We'll start by
+listing the elements used for formatting text:
 
-[anon-block]:https://developer.mozilla.org/en-US/docs/Web/CSS/Visual_formatting_model#anonymous_boxes 
+[^how-anon]: Anonymous block boxes handle cases like an element
+that contains text, formatted text, and also a container. You can
+think of this as a repair mechanism similar to the implicit tags in
+[Chapter 4][html.md].
+
+[anon-block]: https://developer.mozilla.org/en-US/docs/Web/CSS/Visual_formatting_model#anonymous_boxes
 
 ``` {.python}
 INLINE_ELEMENTS = [

--- a/book/layout.md
+++ b/book/layout.md
@@ -689,3 +689,18 @@ document. Hide the scrollbar if the whole document fits onscreen.
 each chapter, enclosed in a `<nav id="toc">` tag, which contains a
 list of links. Add the text "Table of Contents", with a gray
 background, above that list. Don't modify the lexer or parser.
+
+*Anonymous block boxes*: Sometimes, an element has a mix of text-like
+and container-like children. For example, in this HTML,
+
+    <div><i>Hello, </i><b>world!</b><p>So it began...</p></div>
+
+the `<div>` element has three children: the `<i>`, `<b>`, and `<p>`
+elements. The first two are text-like; the last is container-like.
+This is supposed to look like two paragraphs, one for the `<i>` and
+`<b>` and the second for the `<p>`. Make your browser do that.
+Specifically, modify `InlineLayout` so it can be passed a sequence of
+sibling nodes, instead of a single node. Then, modify the algorithm
+that constructs the layout tree so that any sequence of text-like
+elements gets made into a single `InlineLayout`.
+


### PR DESCRIPTION
One confusing in the current version of Chapter 5 is how the browser chooses to use InlineLayout versus BlockLayout. The way it's implemented now, the browser uses `InlineLayout` as long as any child has `display: inline`. That's a problem because it means an extra character somewhere can convert a whole HTML subtree into a single confusing paragraph. Real browsers use anonymous block boxes to do this right, but they're hard to implement here because our layout objects refer to a single element, not a sequence of them like anonymous block boxes.

So this commit just inverts the heuristic from "any child has `display: inline`" to "all children have `display: inline`". Along the way it changes how `InlineLayout` objects work. In the current version a `BlockLayout` either has several `BlockLayout` children, or a single `InlineLayout` child. In the PR's version a `BlockLayout` has any number of children, each of which can be an `InlineLayout` or a `BlockLayout`.

This still mishandles cases like this:

    <p>This <span>is</span> <div>a block</div> inside a paragraph</p>

With the PR's version, there will effectively be four paragraph ("This", "is", "a block", and "inside a paragraph"). The current version will have one paragraph instead. The correct rendering has three paragraphs ("This is", "a block", "inside a paragraph"). I think it'll be less confusing, though I'm willing to hear that we just need to implement anonymous block boxes instead.