### PR TITLE
Totally reorganize the introduction

### DIFF
--- a/book/browsersandweb.md
+++ b/book/browsersandweb.md
@@ -270,9 +270,9 @@ form once all the pieces came together.
 
 In the early days, the Internet was a world wide network of computers, largely
 at universities, labs, and major corporations, linked by physical cables and
-communicating over bespoke, application-specific protocols. The early web built
-on this foundation. Web pages were files stored on specific computers, and web
-browsers used an application-specific protocol to request them. URLs for web
+communicating over application-specific protocols. The early web built on this
+foundation. Web pages were files in a specific format stored on specific
+computers, and web browsers used a custom protocol to request them. URLs for web
 pages named the computer and the file, and early servers did little besides read
 files from a disk. The logical structure of the web mirrored its physical
 structure.

--- a/book/browsersandweb.md
+++ b/book/browsersandweb.md
@@ -49,14 +49,6 @@ declarative UI; it navigates links and represents you to web pages. And of
 course, for web pages to load fast and react smoothly, the browser must be
 hyper-efficient as well.
 
-This web+browsers setup is neither simple nor obvious. In fact, it is the result
-of experimentation and research reaching back to nearly the beginning of
-computing. Of course, the web _also_ needed rich computer displays, powerful
-UI-building libraries, fast networks, and sufficient CPU power and information
-storage capacity. The result was what so often happens with technology: the web
-has many similar-looking predecessors, but only took its modern form once all
-those technologies were available.
-
 Such lofty goals! How does the browser deliver on them? It's a fascinating and
 fun journey. That's what this book is about. But first let's dig deeper into the
 thoughts raised here: how the web works, where the web came from, and the
@@ -266,47 +258,43 @@ fascinating and symbiotic way with the huge number of web pages deployed today.
 The web in history
 ==================
 
-The public Internet and the Web co-evolved, and in fact many peoples’ first
-experiences of the Internet from the 1990s onward were more or less
-experiences with the web. However, it’s important to distinguish between them,
-since the Internet and the web are in fact not synonymous.
+It might seem natural to use a web browser to browser the Web over the Internet,
+and many peoples’ experience of the Internet from the 1990s onward is like this.
+This can make the Web seem already-built, with your place being to browse it.
+But the Web is neither simple nor obvious. It is the result of experiments and
+research reaching back to nearly the beginning of computing. And the web _also_
+needed rich computer displays, powerful UI-building libraries, fast networks,
+and sufficient CPU power and information storage capacity. As so often happens
+with technology, the web has many similar predecessors, but only took its modern
+form once all the pieces came together.
 
-In the early days, the similarity between the _physical structure_ of the
-web---where the web servers were---and the _names_ of the [websites][website]
-was very strong. The Internet was a world wide network of computers, those
-computers had domain names, many of them ran web servers, and those servers
-stored and provided web pages to browsers that asked for them. In this sense, the
-Internet and the web really were closely related at that time. However, there is
-of course nothing inherent about this: nothing forces you to host your own web
-server on your home computer and Internet connection,[^self-hosted] and the same
-goes for a university or corporation. Likewise, there is nothing requiring
-everyone to have their own website rather than a social networking account.
-These days, almost everyone uses a virtual machine or service purchased from one
-kind of cloud computing service or another to run their websites, regardless of
-how small or large, and there are many products available that can easily
-publish your web content on your behalf on various social networking platforms.
+In the early days, the Internet was a world wide network of computers, largely
+at universities, labs, and major corporations, linked by physical cables and
+communicating over bespoke, application-specific protocols. The early web built
+on this foundation. Web pages were files stored on specific computers, and web
+browsers used an application-specific protocol to request them. URLs for web
+pages named the computer and the file, and early servers did little besides read
+files from a disk. The logical structure of the web mirrored its physical
+structure.
 
-[website]: https://en.wikipedia.org/wiki/Website
-
-[^self-hosted]: People actually did this! And when their website became
-popular, it often ran out of bandwidth or computing power and became
-inaccessible.
-
-This same *virtualization* concept also applies to the implementation of web
-pages themselves. While it’s still possible to write HTML by hand, few of the
-most popular web pages' HTML payloads literally exist on a hard drive somewhere.
-Instead, their component pieces and dependent databases exist, and the final
-product is dynamically assembled on the fly by complex build and
-“rendering”[^server-side-rendering] systems and sent over the Internet on-demand
-to your browser. The reason for this is that their contents themselves are
-dynamic---composed of data from news, blog posts, inbox contents,
-advertisements, and algorithms adjusting to your particular tastes.
+A lot has changed. While you can still write HTML files on disk, HTML is now
+usually dynamically assembled on the fly[^server-side-rendering] and sent
+on-demand to your browser. The pieces being assembled are themselves filled with
+dynamic content---news, inbox contents, and advertisements adjusted to your
+particular tastes. Even URLs no longer identify a specific computer---content
+distribution networks route a URL to any of thousands of computers all around
+the world. At a higher level, most people have a web page not on their home
+computer[^self-hosted] but on a social media platform or cloud computing service.
 
 [^server-side-rendering]: "Server-side rendering" is the process of assembling
 HTML on the server when loading a web page. Server-side rendering often uses web
 tech like JavaScript, and even a [headless
 browser](https://en.wikipedia.org/wiki/Headless_browser). Yet one more place
 browsers are taking over!
+
+[^self-hosted]: People actually did this! And when their website became
+popular, it often ran out of bandwidth or computing power and became
+inaccessible.
 
 There is also aforementioned _web app_, which is a computer application written
 entirely as a web page. These applications are widespread, and they are
@@ -322,50 +310,44 @@ _PWA_,[^pwa] which is a web app that progressively becomes indistinguishable fro
 [^pwa]: PWA stands for Progressive Web App. In this case, progressive refers
 to progressive enhancement.
 
-For these reasons, it’s sometimes confusing to know what we should think of as
-“the web”. Here is one definition[^key-web-properties] that gets at the essence of its implementation building blocks:
+With all that's changed, some things have stayed the same: core building blocks
+and the essence of the web:
 
-*   The web is a _network of information_, built at its base on the _HTTP 
-    network protocol_, the _HTML information format_, and the concept of a _
-    hyperlink_.
-*   Its unit of information is a _web page_, which is identified uniquely by
-    its URL (_not_ by its content, which as mentioned above may be dynamic).
-*   Web pages are _documents_ written in HTML.
-*   Web pages can refer, via URL, to auxiliary assets such as images, video,
-    CSS, and JavaScript, that are needed for their functionality.
-*   Web pages _refer to each other_ other with hyperlinks.
-*   The user views and navigates web pages through a _browser_, which is also
-    sometimes called the _User Agent_.
-*   All APIs on the web are open, standardized and free to use or re-use.
+* The web is a _network of information_
+  linked by _hyperlinks_.
+* Information is contained in documents
+  requested with the _HTTP network protocol_
+  and structured with the _HTML information format_.
+* Documents are identified by URLs, _not_ by their content, and may be dynamic.
+* Web pages can link to auxiliary assets in different formats,
+  including images, videos, CSS, and JavaScript.
+* The user uses a _User Agent_, called a _browser_, to navigate the web.
+* All these building blocks are open, standardized, and free to use or re-use.
 
-[^key-web-properties]: It’s worth noting here that this definition is not
-accidental and is part of the original design of the web. The fact that the
-web not only survived but thrived during the process of "virtualization" of
-hosting and content further demonstrates the elegance and effectiveness of
-its original design.
-
-One might try to argue that HTTP, URLs and hyperlinking are the only truly
-essential parts of the Web, or  also argue that a browser is not strictly
-necessary, since conceptually web pages exist independently of the browser for
-them, and could in principle self-render through dedicated
-applications.[^dedicated-applications] In other words, one could try to
-distinguish between the networking and rendering aspects of the web; likewise,
-one could abstract the concept of linking and networking from the particular
-choice of protocols and data formats.
+As a philosophical matter, perhaps one or another of these principles is
+secondary. One could try to distinguish between the networking and rendering
+aspects of the web. One could abstract linking and networking from the
+particular choice of protocol and data format. One could ask whether the browser
+is necessary in theory, or argue that HTTP, URLs and hyperlinking are the only
+truly essential parts of the Web.
 
 [^dedicated-applications]: For example, if you're using an installed PWA, are
 you using a browser?
 
-It is indeed true that one or more of the implementation choices could be
-replaced, and perhaps that will happen over time. For example, JavaScript might
-eventually be replaced by another language or technology, HTTP by some other
-protocol, or HTML by its successor. In practice, it is not really the case that
-networking and rendering are separated, and there are in fact important
-inter-dependencies---for example, HTML plays a critical role in both rendering
-and hyperlinks. It’s best to just consider browsers and HTML (and CSS and
-JavaScript) part of the core definition of the web. In any case, as with all
-technology, the web continues to evolve. The above definition may change over
-time, but for the purposes of this book, it’s a pretty good one.
+Perhaps.[^perhaps] In practice, the web was born when these principles came
+together, not before. They are not accidental; they are the original design of
+the web. And all of them---HTTP, HTML, browsers, URLs---evolve and grow, and
+will continue to do so. The web not only survived but thrived during the
+virtualization of hosting and content, all thanks to the elegance and
+effectiveness of this original design. And [ongoing change](change.md) will lead
+to more changes and evolution in the future. Study the web, read this book,
+and be a part of that evolution.
+
+[^perhaps]: It is indeed true that one or more of the implementation choices
+could be replaced, and perhaps that will happen over time. For example,
+JavaScript might eventually be replaced by another language or technology, HTTP
+by some other protocol, or HTML by its successor. Certainly all of these
+technologies have been through many versions, but the Web has stayed the Web.
 
 Technological precursors
 ========================

--- a/book/history.md
+++ b/book/history.md
@@ -1,0 +1,270 @@
+---
+title: History of the Web
+type: Background
+next: http
+prev: preliminaries
+...
+
+The web is at its core organized around _representing and displaying
+information_, and how to provide a way for humans to effectively learn and
+explore that information. The collective knowledge and wisdom of the species
+long ago exceeded the capacity of a single mind, organization, library, country,
+culture, group or language. However, while we as humans cannot possibly know
+even a tiny fraction of what is possible to know, we can use technology to learn
+more efficiently than before, and most importantly, to quickly access
+information we need to learn or remember. Computers, and the
+Internet, allow us to _process and store_ as much information as we want. The
+_web_, on the other hand, plays the role of _organizing and finding_ that
+information and knowledge to make it useful.[^google-mission]
+
+[^google-mission]: The search engine Google’s [mission](https://about.google/)
+statement to “organize the world’s information and make it universally
+accessible and useful” is almost exactly the same as this. This is not a
+coincidence - the search engine concept is inherently connected to the web.
+
+Technological precursors
+========================
+
+The earliest exploration of how computers might revolutionize information is a
+1945 essay[^memex-essay] entitled [As We May
+Think](https://en.wikipedia.org/wiki/As_We_May_Think). This essay envisioned a
+machine called a [Memex](https://en.wikipedia.org/wiki/Memex). The Memex was an
+imagined machine that helps (think: User Agent) an individual human to see and
+explore all the information in the world. It was described in terms of microfilm
+screen technology of the time, but its purpose and concept has some clear
+similarities to the web as we know it today, even if the user interface and
+technology details differ.
+
+[^memex-essay]: This brief prehistory of the web is by no means exhaustive.
+Instead, you should view it as a brief view into a much larger---and quite
+interesting in its own right---subject.
+
+The concept of networked links of information began to appear in about
+[1964-65](https://en.wikipedia.org/wiki/Hyperlink), when the term “link”
+appeared (though connected to text rather than pages).[^literary-criticism]
+Researchers then began to advocate for building a network of computers to
+realize the concept. Independently, the first hyperlink system appeared (though
+apparently not using that word[^hyperlink-first]) for navigating within a single
+document; it was later generalized to linking between multiple documents. This
+work also formed one of the key parts of the [mother of all
+demos](https://en.wikipedia.org/wiki/The_Mother_of_All_Demos), the most famous
+technology demonstration in the history of computing.
+
+[^hyperlink-first]: The word "hyperlink" may have first appeared in 1987, in
+connection with the HyperCard system on the Macintosh.)
+
+[^literary-criticism]: These concepts are also the computer-based evolution of
+the long tradition of citation in academics and literary criticism.
+
+In 1983 the [HyperTIES](http://www.cs.umd.edu/hcil/hyperties/) system was
+developed around highlighted hyperlinks. This was used to develop the world’s
+first electronically published academic journal, the 1988 issue of the
+[Communications of the ACM](https://cacm.acm.org/). Tim Berners-Lee cites this
+1988 event as the source of the link concept in his World Wide Web
+concept,[^world-wide-web-terminology] in which he proposed to join the link
+concept with the availability of the Internet, thus realizing many of the
+original goals of all the work from previous decades.[^realize-web-decades]
+
+[^world-wide-web-terminology]: Nowadays the World Wide Web is called just “the
+web”, or “the web ecosystem”---ecosystem being another way to capture the same
+concept as “World Wide”). The original wording lives on in the "www" in many
+website domain names.
+
+[^realize-web-decades]: The web itself is, therefore, an example of the
+realization of previous ambitions and dreams, just as today we strive to realize
+the vision laid out by the web. (No, it's not done yet!)
+
+In 1989-1990, the first browser (named “WorldWideWeb”) and web server (named
+“httpd”, for “HTTP Daemon” according to UNIX naming conventions) were born,
+again written in their first version by Berners-Lee. Interestingly, that
+browser’s capabilities were in some ways inferior to the browser you will
+implement in this book,[^no-css] and in some ways go beyond the capabilities
+available even in modern browsers.[^more-less-powerful] On December 20, 1990 the
+[first web page](http://info.cern.ch/hypertext/WWW/TheProject.html) was created.
+The browser we will implement in this book is easily able to render this web
+page, even today.[^original-aesthetics] In 1991, Berners-Lee advertised his
+browser and the concept on the [alt.hypertext Usenet
+group](https://www.w3.org/People/Berners-Lee/1991/08/art-6484.txt).
+
+[^no-css]: No CSS!
+
+[^more-less-powerful]: For example, it included the concept of an index page
+meant for searching within a site (vestiges of which exist today in the
+“index.html” convention when a URL path ends in /”), and had a WYSIWYG web page
+editor (the “contenteditable” HTML attribute and “html()” method on DOM elements
+have similar semantic behavior, but built-in file saving is gone). Today, the
+index is replaced with a search engine, and web page editors as a concept are
+somewhat obsolete due to the highly dynamic nature of today’s web page
+rendering.
+
+[^original-aesthetics]: Also, as you can see clearly, that web page has not been
+updated in the meantime, and retains its original aesthetics!
+
+Berners-Lee has also written a [Brief History of the
+Web](https://www.w3.org/DesignIssues/TimBook-old/History.html) that  highlights
+a number of other interesting factors leading to the establishment of the web as
+we know it. One key factor was its decentralized nature, which he describes as
+arising from the culture of CERN, where he worked. The decentralized nature of
+the web is a key feature that distinguishes it from many systems that came
+before or after, and his explanation of it is worth quoting here (highlight is
+mine):
+
+> There was clearly a need for something like Enquire [ed: a predecessor
+> software system] but accessible to everyone. I wanted it to scale so that if
+> two people started to use it independently, and later started to work
+> together, *they could start linking together their information without
+> making any other changes*. This was the concept of the web.
+
+This quote captures one of the key value propositions of the web. The web was
+successful for several reasons, but I believe it’s primarily the following
+three:
+
+*   It provides a very low-friction way to publish information and applications.
+There is no gatekeeper to doing anything, and it’s easy for novices to make a
+simple web page and publish it.
+
+*   Once bootstrapped, it builds quickly upon itself via [network
+effects](https://en.wikipedia.org/wiki/Network_effect) made possible by
+compatibility between sites and the power of the hyperlink to reinforce this
+compatibility. Hyperlinks drive traffic between sites, but also into the web
+_from the outside_, via email, social networking, and search engines.
+
+*   It is outside the control of any one entity - and kept that way via
+standards organizations - and therefore not subject to problems of monopoly
+control or manipulation.
+
+The browser ecosystem
+=====================
+
+Browsers have a unique character in that they are _not proprietary_---no company
+controls the APIs of the web and there are multiple independent implementations.
+In addition, it turned out that over time almost all of the code became
+open-source and developed by a very wide array of people and entities. As a
+corollary, the software platform for web pages is also not proprietary, and the
+information and capabilities contained within them are easy to make accessible 
+to everyone.[^unless-restricted]
+
+[^unless-restricted]: Unless, of course, the web page owner chooses to restrict
+availability for one reason or another. The point is that the _web platform_
+does not restrict availability, and therefore the owner has the freedom to
+choose.
+
+I'll now give a brief overview of the evolution of browser implementations. The
+first _widely distributed_ browser may have been
+[ViolaWWW](https://en.wikipedia.org/wiki/ViolaWWW); this browser also pioneered
+multiple interesting features such as applets and images. This browser was in
+turn the inspiration for [NCSA
+Mosaic](https://en.wikipedia.org/wiki/Mosaic_(web_browser)), which launched in
+1993. One of the two original authors of Mosaic went on to co-found
+[Netscape](https://en.wikipedia.org/wiki/Netscape_Navigator), the first
+_commercial browser_,[^commercial-browser] which launched in 1994. The era of
+the [”first browser
+war”](https://en.wikipedia.org/wiki/Browser_wars#First_Browser_War_(1995%E2%80%932001))
+ensued, in a competition between Netscape and Internet Explorer. In addition,
+there were other browsers with smaller market shares; one notable example is
+[Opera](https://en.wikipedia.org/wiki/Opera_(web_browser)). The
+[WebKit](https://en.wikipedia.org/wiki/WebKit) project began in 1999
+([Safari](https://en.wikipedia.org/wiki/Safari_(web_browser)) and
+[Chromium](https://www.chromium.org/)-based browsers, such as Chrome and newer
+versions of [Edge](https://en.wikipedia.org/wiki/Microsoft_Edge), descend from
+this codebase). Likewise, the
+[Gecko](https://en.wikipedia.org/wiki/Gecko_(software)) rendering engine was
+originally developed by Netscape starting in 1997; the
+[Firefox](https://en.wikipedia.org/wiki/Firefox) browser is descended from this
+codebase.  During the first browser war period, nearly all of the core features
+you will implement in your browser that goes along with this book were added,
+including CSS, DOM, and JavaScript.
+
+ The "second browser war", which according to Wikipedia was
+[2004-2017](https://en.wikipedia.org/wiki/Browser_wars#Second_Browser_War_(2004%E2%80%932017)),
+was between a variety of browsers - Internet Explorer, Firefox, Safari and
+Chrome in particular. Chrome split off its rendering engine subsystem into its
+own code base called
+[Blink](https://en.wikipedia.org/wiki/Blink_(browser_engine)) in 2013.
+
+[^commercial-browser]: By commercial I mean built by a for-profit entity.
+Netscape's early versions were also not free software---you had to buy them from
+a store.
+
+In parallel with these developments was another, equally important, one---the
+standardization of web APIs. In October 1994, the [World Wide Web
+Consortium](https://www.w3.org/Consortium/facts) (W3C) was founded in order to
+provide oversight and standards for web features. After this point, browsers
+would often introduce new HTML elements or APIs, and competing browsers would
+copy them. Those elements and APIs were subsequently agreed upon and documented
+in W3C specifications. (These days, an initial discussion,  design and
+specification precedes any new feature.) Later on, the HTML specification ended
+up moving to a different standards body called the
+[WHATWG](https://whatwg.org/), but [CSS](https://drafts.csswg.org/) and other
+features are still standardized at the W3C. JavaScript is standardized at
+[TC39](https://tc39.es/) (“Technical Committee 39” at
+[ECMA](https://www.ecma-international.org/memento/history.htm), yet another
+standards body). [HTTP](https://tools.ietf.org/html/rfc2616) is standardized by
+the [IETF](https://www.ietf.org/about/).
+
+In the first years of the web, it was not so clear that browsers would remain
+standard and that one browser might not end up “winning” and becoming another
+proprietary software platform. There are multiple reasons this didn’t happen,
+among them the egalitarian ethos of the computing community and the presence and
+strength of the W3C.  Equally important was the networked nature of the web, and
+therefore the desire of web developers to make sure their pages worked correctly
+in most or all of the browsers (otherwise they would lose customers), leading
+them to avoid any proprietary extensions.
+
+Despite fears that this might happen, there never really was a point where any
+browser openly attempted to break away from the standard. Instead, intense
+competition for market share was channeled into very fast innovation and an
+ever-expanding set of APIs and capabilities for the web, which we nowadays refer
+to as _the web platform,_ not just the “World Wide Web”. This recognizes the
+fact that the web is no longer a document viewing mechanism, but has evolved
+into a fully realized computing platform and ecosystem.[^web-os]
+
+Given these outcomes, in retrospect it is clearly not so relevant to
+know which browser “won” or “lost” each of the browser “wars”. In both cases
+_the web won_ and was preserved and enhanced for the benefit of the world. In
+economics terms, enforcing a standard set of APIs across browsers made the web
+platform a _commodity_; instead of competing based on lock-in, browsers compete
+on _performance_ and _quality_, and also _browser features_ that are not part of
+the web platform---for example, tabbed UIs and search engine integration.[^monetization]
+
+[^monetization]: Browser development is also primarily funded by revenue from
+search engine advertisements; a secondary typical funding motivation is to
+improve the competitive position of an operating system or device owned or
+controlled by the company building the browser. (Compare this with the RedHat
+anecdote I related earlier!)
+
+[^web-os]: There have even been operating systems built around the web! Examples
+include [webOS](https://en.wikipedia.org/wiki/WebOS), which powered some Palm
+smartphones, [Firefox OS](https://en.wikipedia.org/wiki/Firefox_OS) (that today
+lives on in [KaiOS](https://en.wikipedia.org/wiki/KaiOS)-based phones), and
+[ChromeOS](https://en.wikipedia.org/wiki/Chrome_OS), which is a desktop
+operating system. All of these OSes are based on using the Web as the UI layer
+for all applications, with some JavaScript-exposed APIs on top for system
+integration.
+
+
+An important and interesting outcome of the _second_ browser war was that all
+mainstream browsers today (of which there are *many* more than
+three[^examples-of-browsers-today]) are based on _three open-source web
+rendering / JavaScript engines_: Chromium, Gecko and WebKit.[^javascript-repo]
+Since Chromium and WebKit have a common ancestral codebase, while Gecko is an
+open-source descendant of Netscape, all three date back to the 1990s---almost to
+the beginning of the web. That this occurred is not an accident, and in fact
+tells us something quite interesting about the most cost-effective way to
+implement a rendering engine based on a commodity set of platform APIs.
+
+[^examples-of-browsers-today]: Examples of Chromium-based browsers include
+Chrome, Edge, Opera (which switched to Chromium from the
+[Presto](https://en.wikipedia.org/wiki/Presto_(browser_engine)) engine in 2013),
+Samsung Internet, Yandex Browser, and UC Browser. In addition, there are many
+"embedded" browsers, based on one or another of the three engines, for a wide
+variety of automobiles, phones, TVs and other electronic devices.
+
+[^javascript-repo]: The JavaScript engines are actually in different
+repositories (as are various other sub-components that we won’t get into here),
+and can and do exist outside of browsers as JavaScript virtual machines. One
+important such application is the use of
+[v8](https://en.wikipedia.org/wiki/V8_(JavaScript_engine)) to power
+[node.js](https://en.wikipedia.org/wiki/Node.js). However, each of the three
+rendering engines does have its own JavaScript implementation, so conflating the
+two is reasonable.

--- a/book/intro.md
+++ b/book/intro.md
@@ -1,0 +1,373 @@
+---
+title: Browsers and the Web
+type: Introduction
+next: http
+prev: preliminaries
+...
+
+I[^chris] have known the web[^theweb] for all of my adult life. Ever since I
+first encountered the web, and its predecessors,[^bbs] in the early 90s, I was
+fascinated by browsers and the concept of networked user interfaces. When I
+[surfed][websurfing] the web, even in its earliest form, I felt I was seeing the
+future of computing. In some ways, the web and I grew together---for example, in
+1994, the year the web went commercial, was the same year I started college;
+while there I spent a fair amount of time surfing it, and by the time I
+graduated in 1999, the browser had fueled the famous dot-com speculation gold
+rush. The company for which I now work, Google, is a child of the web and was
+founded during that time. The web for me is something of a technological
+companion, and I’ve never been far from it in my studies or work.
+
+[^chris]: This is Chris speaking!
+
+[^theweb]: Broadly defined, the web is the interlinked network (“web”)
+of [web pages](https://en.wikipedia.org/wiki/Web_page) on the
+Internet. If you've never made a web page, I recommend MDN's [Learn
+Web Development][learn-web] series, especially the [Getting
+Started][learn-basics] guide. This book will be easier to read if
+you're familiar with the core technologies.
+    
+[learn-web]: https://developer.mozilla.org/en-US/docs/Learn
+[learn-basics]: https://developer.mozilla.org/en-US/docs/Learn/Getting_started_with_the_web
+
+[websurfing]: https://www.pcmag.com/encyclopedia/term/web-surfing
+
+[^bbs]: For me, [BBS](https://en.wikipedia.org/wiki/Bulletin_board_system)
+systems over a dial-up modem connection. A BBS is not all that different from a
+browser if you think of it as a window into dynamic content created somewhere
+else on the Internet.
+
+The browser and me
+==================
+
+In my freshman year at college, I attended a presentation by a RedHat salesman.
+The presentation was of course aimed at selling RedHat Linux, probably calling
+it the "operating system of the future" and speculating about the "year of the
+Linux desktop". But when asked about challenges RedHat faced, the salesman
+mentioned not Linux but _the web_: he said that someone "needs to make a good
+browser for Linux."[^netscape-linux] Even back then, in the very first year or
+so of the web, the browser was already a necessary component of every computer.
+He even threw out a challenge: "how hard could it be to build a better browser?"
+Indeed, how hard could it be? What makes it so hard? That question stuck with me
+for a long time.[^meantime-linux]
+
+[^netscape-linux]: Netscape Navigator was available for Linux at that time, but
+it wasn’t viewed as especially fast or featureful compared to its implementation
+on other operating systems.
+
+[^meantime-linux]: Meanwhile, the "better Linux browser than Netscape" took a
+long time to appear....
+
+How hard indeed! After seven years in the trenches working on Chrome, I now know
+the answer to his question: building a browser is both easy and incredibly hard,
+both intentional and accidental, both planned and organic, both simple and
+unimaginably complex. And everywhere you look, you see the evolution and history of
+the web wrapped up in one codebase.
+
+That's what this book is about. It's a fascinating and fun journey.
+But first let's dig deeper into how the web works, where the web came
+from, and the role browsers play.
+
+The web in history
+==================
+
+It might seem natural to use a web browser to browse the Web over the Internet,
+and many people experienced the Internet of the 1990s onward like this. That can
+make the Web seem already-built, simple and obvious, with nothing left but to
+browse it. But the Web is neither simple nor obvious. It is the result of
+experiments and research reaching back to nearly the beginning of computing. And
+the web _also_ needed rich computer displays, powerful UI-building libraries,
+fast networks, and sufficient CPU power and information storage capacity. As so
+often happens with technology, the web has many similar predecessors, but only
+took its modern form once all the pieces came together.
+
+In the early days, the Internet was a world wide network of computers, largely
+at universities, labs, and major corporations, linked by physical cables and
+communicating over application-specific protocols. The early web built on this
+foundation. Web pages were files in a specific format stored on specific
+computers, and web browsers used a custom protocol to request them. URLs for web
+pages named the computer and the file, and early servers did little besides read
+files from a disk. The logical structure of the web mirrored its physical
+structure.
+
+A lot has changed. While you can still write HTML files on disk, HTML is now
+usually dynamically assembled on the fly[^server-side-rendering] and sent
+on-demand to your browser. The pieces being assembled are themselves filled with
+dynamic content---news, inbox contents, and advertisements adjusted to your
+particular tastes. Even URLs no longer identify a specific computer---content
+distribution networks route a URL to any of thousands of computers all around
+the world. At a higher level, most web page are served not from someone's home
+computer[^self-hosted] but from a social media platform or cloud computing
+service.
+
+[^server-side-rendering]: "Server-side rendering" is the process of assembling
+HTML on the server when loading a web page. Server-side rendering often uses web
+tech like JavaScript, and even a [headless
+browser](https://en.wikipedia.org/wiki/Headless_browser). Yet one more place
+browsers are taking over!
+
+[^self-hosted]: People actually did this! And when their website became
+popular, it often ran out of bandwidth or computing power and became
+inaccessible.
+
+With all that's changed, some things have stayed the same, the core building
+blocks that are the essence of the web:
+
+* The web is a _network of information_
+  linked by _hyperlinks_.
+* Information is contained in documents
+  requested with the _HTTP network protocol_
+  and structured with the _HTML information format_.
+* Documents are identified by URLs, _not_ by their content, and may be dynamic.
+* Web pages can link to auxiliary assets in different formats,
+  including images, videos, CSS, and JavaScript.
+* The user uses a _User Agent_, called a _browser_, to navigate the web.
+* All these building blocks are open, standardized, and free to use or re-use.
+
+As a philosophical matter, perhaps one or another of these principles is
+secondary. One could try to distinguish between the networking and rendering
+aspects of the web. One could abstract linking and networking from the
+particular choice of protocol and data format. One could ask whether the browser
+is necessary in theory, or argue that HTTP, URLs and hyperlinking are the only
+truly essential parts of the Web.
+
+Perhaps.[^perhaps] In practice, the web was born when these principles came
+together, not before. They are not accidental; they are the original design of
+the web. And all of them---HTTP, HTML, browsers, URLs---evolve and grow, and
+will continue to do so. The web not only survived but thrived during the
+virtualization of hosting and content, all thanks to the elegance and
+effectiveness of this original design. And [ongoing change](change.md) will lead
+to more changes and evolution in the future.
+
+[^perhaps]: It is indeed true that one or more of the implementation choices
+could be replaced, and perhaps that will happen over time. For example,
+JavaScript might eventually be replaced by another language or technology, HTTP
+by some other protocol, or HTML by its successor. Certainly all of these
+technologies have been through many versions, but the Web has stayed the Web.
+
+How browsers evolve
+===================
+
+Some time during my first few months of working on Chrome, I came across the
+code implementing the [`<br>`][br-tag] tag---look at that, the good-old `<br>`
+tag that I’ve used many times to insert newlines into web pages! And the
+implementation turns out to be barely any code at all, both in Chrome and in
+this book's simple browser.
+
+[br-tag]: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/br
+
+But a browser with the features, speed, security, and reliability of today’s top
+browsers---_wow_. _Thousands_ of person-years of effort have gone into the
+browser you use today. And keeping a browser competitive is a lot of work as
+well. Not only is there an inherent cost to maintaining large codebases, there
+is also constant pressure to do more---to add more features, to improve
+performance, to keep up with the "web ecosystem"---for the thousands of
+businesses, millions of developers, and billions of users on the web.
+
+Every browser has thousands of unfixed bugs, from the smallest of mistakes to
+myriad mix ups and mismatches. Every browser has a complicated set of
+optimizations to squeeze out that last bit of performance. Every browser
+requires painstaking work to continuously refactor the code to reduce its
+complexity, often through the careful[^browsers-abstraction-hard] introduction
+of modularization and abstraction.
+
+[^browsers-abstraction-hard]: Browsers are so performance-sensitive that, in
+many places, merely the introduction of an abstraction---the function call or
+branching overhead---has an unacceptable performance cost.
+
+Working on such a codebase is often daunting. For one thing, there is the
+weighty history of each browser. It’s not uncommon to find lines of code last
+touched 15 years ago by someone who you’ve never met; or even after years of
+working discover files and code that you didn’t even know existed; or see lines
+of code that don’t look necessary, yet seem to do something important. How do I
+learn what that 15-year-old code does? Does that code I just discovered matter
+at all? Can I delete those lines of code, or are they there for a reason?
+
+These questions are common to all complex codebases. But what makes a browser
+different is that there is often an _urgency to fix_ them. Browsers are nearly
+as old as any “legacy” codebase, but are _not_ legacy, not abandoned or
+half-deprecated, not slated for replacement. On the contrary, they are vital to
+the world’s economy. And since the character of the web itself is highly
+decentralized, the use cases met by browsers are to a significant extent _not
+determined_ by the companies “owning” or “controlling” a particular browser.
+Other people, for example web developers, contribute ideas and proposals that
+end up implemented inside browsers. Browser engineers must therefore fix and
+improve rather than abandon and replace.
+
+Every rendering engine today is open-source, which share the burden of
+maintenance and feature development across that larger community of web
+developers. So browsers evolve like giant R&D projects, where new ideas are
+constantly being proposed and tested out. Like any R&D project, browsers have an
+iterative and incremental planning and shipping process. And just as you would
+expect, some features fail and some succeed. The ones that succeed end up in
+specifications and are implemented by other browsers.
+
+Explaining the black box
+========================
+
+HTML, CSS, HTTP, hyperlinks, and JavaScript---the core of the web---are
+approachable enough, and if you've made a web page before you've seen that
+programming ability is not required. That's because HTML & CSS are meant to be
+black boxes---declarative APIs---where one specifies _what_ outcome to achieve,
+and the _browser itself_ is responsible for figuring out the _how_ to achieve
+it. Web developers don't, and mostly can't, draw their web page's pixels on
+their own.
+
+There are philosophical and practical reasons for this unusual design. Yes,
+developers lose some control and agency---when those pixels are wrong,
+developers cannot fix them directly.[^loss-of-control] But they gain the ability
+to deploy content on the web without worrying about the details, to make that
+content instantly available on almost every computing device in existence, and
+to keep it accessible in the future, mostly avoiding the inevitable obsolescence
+of most software.
+
+[^loss-of-control]: Loss of control is not necessarily specific to the web---much
+of computing these days relies on mountains of other peoples’ code.
+
+As a black box, the browser is either magical or frustrating (depending on
+whether it is working correctly or not!). Few people---even among professional
+software developers[^software-developers]---know much about how a browser
+renders web pages. But it turns out that a browser is a pretty unusual piece of
+software, with unique challenges, interesting algorithms, and clever
+optimizations invented just for this domain. That makes browsers worth studying
+for the pure pleasure of it---even leaving aside their importance!
+
+[^software-developers]: I usually prefer “engineer”---hence the title of this
+book---but “developer” or “web developer” is much more common on the web. One
+important reason is that anyone can build a web page---not just trained software
+engineers and computer scientists. “Web developer” also is more inclusive of
+additional, critical roles like designers, authors, editors, and photographers.
+A web developer is anyone who makes web pages, regardless of how.
+
+Inside the black box lie the web browser's implementations of [inversion of
+control][inversion], [constraint programming][constraints], and [declarative
+programming][declarative]. The web _inverts control_, with an intermediary---the
+browser---handling most of the rendering, and the web developer specifying
+parameters and content to this intermediary.[^forms] Further, these parameters
+usually take the form of _constraints_ over relative sizes and positions instead
+of specifying their values directly;[^constraints] the browser solves the
+constraints to find those values. The same idea applies for actions: web pages
+mostly require _that_ actions take place without specifying _when_ they do. This
+_declarative_ style means that from the point of view of a developer, changes
+"apply immediately," but under the hood, the browser can be [lazy][lazy] and
+delay applying the changes until they become externally visible, either due to
+subsequent API calls or because the page has to be displayed to the
+user.[^style-calculation]
+
+[inversion]: https://en.wikipedia.org/wiki/Inversion_of_control
+[constraints]: https://en.wikipedia.org/wiki/Constraint_programming.
+[declarative]: https://en.wikipedia.org/wiki/Declarative_programming
+[lazy]: https://en.wikipedia.org/wiki/Lazy_evaluation
+
+[^forms]: For example, in HTML there are many built-in [form control
+elements][forms] that take care of the various ways the user of a web page can
+provide input. The developer need only specify parameters such as button names,
+sizing, and look-and-feel, or JavaScript extension points to handle form
+submission to the server. The rest of the implementation is taken care of by the
+browser.
+
+[forms]: https://developer.mozilla.org/en-US/docs/Learn/Forms/Basic_native_form_controls
+
+[^constraints]: Constraint programming is clearest during web page layout, where
+font and window sizes, desired positions and sizes, and the relative arrangement
+of widgets is rarely specified directly. A fun question to consider: what does
+the browser "optimize for" when computing a layout?
+
+[^style-calculation]: For example, when exactly does the browser compute which
+CSS styles apply to which HTML elements, after a web page changes
+those styles? The change is visible to all subsequent API calls, so in that
+sense it applies "immediately." But it is better for the browser to delay style
+re-calculation, avoiding redundant work if styles change twice in quick
+succession. Maximally exploiting the opportunities afforded by declarative
+programming makes real-world browsers very complex.
+
+Understanding how the browser works yields true insights into computing. To me,
+browsers are where algorithms _come to life_. A browser contains a rendering
+engine more complex and powerful than any computer game; a full networking
+stack; clever data structures and parallel programming techniques; a virtual
+machine, an interpreted language, and a JIT; a world-class security sandbox; and
+a uniquely dynamic system for storing data.
+
+
+The role of the browser
+=======================
+
+The browser, and the web more broadly, is a marvel. It now goes far beyond its
+original use for document-based information sharing, and every year it expands
+its reach to more and more of what we do with computers. Many people now spend
+their entire day in a browser, not using a single other application!
+
+Moreover, desktop applications are now often built and delivered as _web apps_:
+web pages loaded by a browser but used like installed applications.[^pwa] Even
+on mobile devices, apps often embed a browser to render parts of the application
+UI.[^hybrid] Perhaps in the future both desktop and mobile devices will largely
+be a container for web apps. Already, browsers are a critical and indispensable
+part of computing.
+
+[^pwa]: Related to the notion of a web app is a Progressive Web App, which is a
+web app that becomes indistinguishable from a native app through [progressive
+enhancement][prog-enhance-def].
+
+[^hybrid]: The fraction of such "hybrid" apps that are shown via a "web view" is
+    likely increasing over time. In some markets like China, "super-apps" act
+    like a mobile web browser for web-view-based games and widgets.
+
+The basis of browsers is the web. And the web itself is built on a few simple,
+yet revolutionary, concepts; concepts that that together present a vision of the
+future of software and information. Among them are open, decentralized and safe
+computing; a declarative document model for describing UIs; hyperlinks; and the
+User Agent.[^useragent] 
+
+[^useragent]: The User Agent concept views a computer, or software within the
+    computer, as a trusted assistant and advocate of the human user.
+
+From our point of view, the browser makes the web real. All these concepts and
+principles therefore form the core architecture of the browser itself. The
+browser is the User Agent, but also the _mediator_ of web interactions and
+_enforcer_ of the rules. It ensures safety and fairness and represents you to
+web pages. Not only that, the browser is the _implementer_ of all of the ways
+information is explored. Its sandbox keeps web browsing safe; its algorithms
+implement the declarative UI; its UI navigates links. For web pages to load fast
+and react smoothly, the browser must be hyper-efficient.
+
+Such lofty goals! How does the browser deliver on them? The best way to
+understand that question is to build a web browser.
+
+Browsers and you
+================
+
+This book explains how to build a simple web rendering engine plus browser
+shell. As you’ll see, it’s surprisingly easy to write a very simple browser, one
+that can---despite its simplicity---display interesting-looking web pages and
+support many interesting behaviors.[^prog-enhance] Moreover, this simple browser
+will demonstrate all the core concepts you need to understand to predict the
+behavior of a real-world browser. You'll see what is easy and what is hard in
+these engines; which algorithms are simple, and which are tricky; what makes a
+browser fast, and what makes it slow.
+
+[^prog-enhance]: You might relate this to the history of the web and the idea of
+[progressive enhancement][prog-enhance-def].
+
+[prog-enhance-def]:
+https://en.wikipedia.org/wiki/Progressive_enhancement
+
+The intention is for you to build your own browser as you work through the early
+chapters. Once your browser is up and running, there are endless opportunities
+to improve performance or add features. Many of the exercises at the ends of the
+chapters are feature implemented in real browsers. We encourage you to try
+them---adding features is one of the best parts of browser development! It is
+lot of fun (and very satisfying) to compare your browser with a real one, or to
+see how many websites you can successfully render.
+
+This simple browser demonstrates the (intentionally!) easy-to-implement core of
+the web architecture. The book then moves on to details about advanced features
+and the architecture of a real browser’s rendering engine, based on my
+experiences with Chrome. After finishing the book, you should be able to dig
+into the source code for a real browser’s rendering engine and understand it
+without too much trouble.
+
+I hope the book lets you appreciate a browser's depth, complexity, and power. I
+hope the book passes along its beauty---its clever algorithms and data
+structures, its co-evolution with the culture and history of computing, its
+centrality in our world. But most of all, I hope the book lets you see in
+yourself someone building the browser of the future. The future doesn't just
+arrive; it’s up to you to invent and discover and create it!

--- a/book/intro.md
+++ b/book/intro.md
@@ -21,7 +21,7 @@ companion, and I’ve never been far from it in my studies or work.
 
 [^theweb]: Broadly defined, the web is the interlinked network (“web”)
 of [web pages](https://en.wikipedia.org/wiki/Web_page) on the
-Internet. If you've never made a web page, I recommend MDN's [Learn
+internet. If you've never made a web page, I recommend MDN's [Learn
 Web Development][learn-web] series, especially the [Getting
 Started][learn-basics] guide. This book will be easier to read if
 you're familiar with the core technologies.
@@ -34,7 +34,7 @@ you're familiar with the core technologies.
 [^bbs]: For me, [BBS](https://en.wikipedia.org/wiki/Bulletin_board_system)
 systems over a dial-up modem connection. A BBS is not all that different from a
 browser if you think of it as a window into dynamic content created somewhere
-else on the Internet.
+else on the internet.
 
 The browser and me
 ==================
@@ -70,17 +70,17 @@ from, and the role browsers play.
 The web in history
 ==================
 
-It might seem natural to use a web browser to browse the Web over the Internet,
-and many people experienced the Internet of the 1990s onward like this. That can
-make the Web seem already-built, simple and obvious, with nothing left but to
-browse it. But the Web is neither simple nor obvious. It is the result of
+It might seem natural to use a web browser to browse the web over the internet,
+and many people experienced the internet of the 1990s onward like this. That can
+make the web seem already-built, simple and obvious, with nothing left but to
+browse it. But the web is neither simple nor obvious. It is the result of
 experiments and research reaching back to nearly the beginning of computing. And
 the web _also_ needed rich computer displays, powerful UI-building libraries,
 fast networks, and sufficient CPU power and information storage capacity. As so
 often happens with technology, the web has many similar predecessors, but only
 took its modern form once all the pieces came together.
 
-In the early days, the Internet was a world wide network of computers, largely
+In the early days, the internet was a world wide network of computers, largely
 at universities, labs, and major corporations, linked by physical cables and
 communicating over application-specific protocols. The early web built on this
 foundation. Web pages were files in a specific format stored on specific
@@ -128,7 +128,7 @@ secondary. One could try to distinguish between the networking and rendering
 aspects of the web. One could abstract linking and networking from the
 particular choice of protocol and data format. One could ask whether the browser
 is necessary in theory, or argue that HTTP, URLs and hyperlinking are the only
-truly essential parts of the Web.
+truly essential parts of the web.
 
 Perhaps.[^perhaps] In practice, the web was born when these principles came
 together, not before. They are not accidental; they are the original design of
@@ -142,7 +142,7 @@ to more changes and evolution in the future.
 could be replaced, and perhaps that will happen over time. For example,
 JavaScript might eventually be replaced by another language or technology, HTTP
 by some other protocol, or HTML by its successor. Certainly all of these
-technologies have been through many versions, but the Web has stayed the Web.
+technologies have been through many versions, but the web has stayed the web.
 
 How browsers evolve
 ===================


### PR DESCRIPTION
This PR is parallel to an email I sent @chrishtr which proposes a reorganization of the intro. You can see the revised intro here:

https://browser.engineering/draft/intro.html

Unfortunately browsing the diff on Github is mostly uninformative. In short, this reorg tries to fix two problems:

- The four history sections aren't obviously connected to the rest of the chapter.
- The "Browser and me" section feels too long and a bit unfocused.

To fix these, the reorg:

- Refocuses "The web in history" to focus on change and how reading the book puts the reader into this historical process. I have a separate PR (#68) to do only this.
- Splits "the browser and me" in two. The paragraphs starting at "Even in real browsers" discuss the software engineering that goes into a web browser. Those are merged with the "How browsers evolve" section, which also talks about software engineering. That merged section is placed after the "The web in history" section, which introduces the idea of browsers changing, core principles like openness, and the reader's role in the process.
- Splits the remaining two history sections ("Technological precursors" and "The browser ecosystem") into their own chapter. Right now, editing these sections is an uncomfortable tension between shortening (because these sections are so detailed and historically focused that they lose the emotional pull of the chapter) and lengthening (because the history is interesting and there are lessons to elaborate on).

In short, the proposal is to reorganize the introductory chapter to look like this (https://browser.engineering/draft/intro.html) and to expand the history chapter, at least by moving many of the footnotes in line but also expanding them where it's interesting.