### PR TITLE
Rename some drawing-related stuff

### DIFF
--- a/book/layout.md
+++ b/book/layout.md
@@ -483,17 +483,17 @@ contains *commands*, and we'll have two types of commands:
 ``` {.python}
 class DrawText:
     def __init__(self, x1, y1, text, font):
-        self.x1 = x1
-        self.y1 = y1
+        self.top = y1
+        self.left = x1
         self.text = text
         self.font = font
     
 class DrawRect:
     def __init__(self, x1, y1, x2, y2, color):
-        self.x1 = x1
-        self.y1 = y1
-        self.x2 = x2
-        self.y2 = y2
+        self.top = y1
+        self.left = x1
+        self.bottom = y2
+        self.right = x2
         self.color = color
 ```
 
@@ -535,7 +535,7 @@ canvas. Let's do this with an `execute` method for each command. On
 class DrawText:
     def execute(self, scroll, canvas):
         canvas.create_text(
-            self.x1, self.y1 - scroll,
+            self.left, self.top - scroll,
             text=self.text,
             font=self.font,
             anchor='nw',
@@ -554,21 +554,21 @@ sure to pass `width = 0`:
 class DrawRect:
     def execute(self, scroll, canvas):
         canvas.create_rectangle(
-            self.x1, self.y1 - scroll,
-            self.x2, self.y2 - scroll,
+            self.left, self.top - scroll,
+            self.right, self.bottom - scroll,
             width=0,
             fill=self.color,
         )
 ```
 
 We do still want to skip graphics commands that occur offscreen, and
-`DrawRect` already contains a `y2` field we can use, so let's add the
-same to `DrawText`:
+`DrawRect` already contains a `bottom` field we can use, so let's add
+the same to `DrawText`:
 
 ``` {.python}
 def __init__(self, x1, y1, text, font):
     # ...
-    self.y2 = y1 + font.metrics("linespace")
+    self.bottom = y1 + font.metrics("linespace")
 ```
 
 ::: {.quirks}

--- a/src/lab5.py
+++ b/src/lab5.py
@@ -324,7 +324,7 @@ class BlockLayout:
             x2, y2 = self.x + self.w, self.y + self.h
             display_list.append(DrawRect(self.x, self.y, x2, y2, "gray"))
         for child in self.children:
-            child.draw(to)
+            child.draw(display_list)
 
 class DocumentLayout:
     def __init__(self, node):

--- a/src/lab5.py
+++ b/src/lab5.py
@@ -271,9 +271,9 @@ class InlineLayout:
         max_descent = max([metric["descent"] for metric in metrics])
         self.cy = baseline + 1.2 * max_descent
 
-    def draw(self, to):
+    def draw(self, display_list):
         for x, y, word, font in self.display_list:
-            to.append(DrawText(x, y, word, font))
+            display_list.append(DrawText(x, y, word, font))
 
 INLINE_ELEMENTS = [
     "a", "em", "strong", "small", "s", "cite", "q", "dfn", "abbr",
@@ -319,10 +319,10 @@ class BlockLayout:
 
         self.h = sum([child.h for child in self.children])
 
-    def draw(self, to):
+    def draw(self, display_list):
         if self.node.tag == "pre":
             x2, y2 = self.x + self.w, self.y + self.h
-            to.append(DrawRect(self.x, self.y, x2, y2, "gray"))
+            display_list.append(DrawRect(self.x, self.y, x2, y2, "gray"))
         for child in self.children:
             child.draw(to)
 
@@ -343,8 +343,8 @@ class DocumentLayout:
         child.layout()
         self.h = child.h + 2*VSTEP
 
-    def draw(self, to):
-        self.children[0].draw(to)
+    def draw(self, display_list):
+        self.children[0].draw(display_list)
 
 class DrawText:
     def __init__(self, x1, y1, text, font):
@@ -355,7 +355,7 @@ class DrawText:
 
         self.y2 = y1 + font.metrics("linespace")
 
-    def draw(self, scroll, canvas):
+    def execute(self, scroll, canvas):
         canvas.create_text(
             self.x1, self.y1 - scroll,
             text=self.text,
@@ -371,7 +371,7 @@ class DrawRect:
         self.y2 = y2
         self.color = color
 
-    def draw(self, scroll, canvas):
+    def execute(self, scroll, canvas):
         canvas.create_rectangle(
             self.x1, self.y1 - scroll,
             self.x2, self.y2 - scroll,
@@ -408,7 +408,7 @@ class Browser:
         for cmd in self.display_list:
             if cmd.y1 > self.scroll + HEIGHT: continue
             if cmd.y2 < self.scroll: continue
-            cmd.draw(self.scroll, self.canvas)
+            cmd.execute(self.scroll, self.canvas)
 
     def scrolldown(self, e):
         self.scroll = self.scroll + SCROLL_STEP

--- a/src/lab5.py
+++ b/src/lab5.py
@@ -348,16 +348,16 @@ class DocumentLayout:
 
 class DrawText:
     def __init__(self, x1, y1, text, font):
-        self.x1 = x1
-        self.y1 = y1
+        self.top = y1
+        self.left = x1
         self.text = text
         self.font = font
 
-        self.y2 = y1 + font.metrics("linespace")
+        self.bottom = y1 + font.metrics("linespace")
 
     def execute(self, scroll, canvas):
         canvas.create_text(
-            self.x1, self.y1 - scroll,
+            self.left, self.top - scroll,
             text=self.text,
             font=self.font,
             anchor='nw',
@@ -365,16 +365,16 @@ class DrawText:
 
 class DrawRect:
     def __init__(self, x1, y1, x2, y2, color):
-        self.x1 = x1
-        self.y1 = y1
-        self.x2 = x2
-        self.y2 = y2
+        self.top = y1
+        self.left = x1
+        self.bottom = y2
+        self.right = x2
         self.color = color
 
     def execute(self, scroll, canvas):
         canvas.create_rectangle(
-            self.x1, self.y1 - scroll,
-            self.x2, self.y2 - scroll,
+            self.left, self.top - scroll,
+            self.right, self.bottom - scroll,
             width=0,
             fill=self.color,
         )


### PR DESCRIPTION
This renames the draw commands' `draw` method to `execute`, so that method names are never accidentally shared. It also renames the confusing "to" parameter.