### PR TITLE
Close inline footnotes by default on small screens.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 www/*.html
-www/*.js
+www/*example.js
 www/draft/*.html
 www/draft/*.js
 www/blog/*.html

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
 FLAGS=
+SCRIPTS=--variable=script:../feedback.js --variable=script:../book.js
 
 ORDERED_PAGES=preface intro history http graphics text html layout styles chrome forms scripts reflow security visual-effects skipped change glossary
 
@@ -10,11 +11,11 @@ draft: $(patsubst book/%.md,www/draft/%.html,$(wildcard book/*.md)) $(patsubst b
 
 onepage/%.html: book/%.md book/template-onepage.html book/filter.lua disabled.conf
 	mkdir -p $(dir $@)
-	pandoc --toc --template book/template-onepage.html $(FLAGS) -c book.css --variable=script:feedback.js $(PANDOC_COMMON_ARGS) --metadata=mode:draft -c ../book.css $< -o $@
+	pandoc --toc --template book/template-onepage.html $(FLAGS) -c book.css ${SCRIPTS} $(PANDOC_COMMON_ARGS) --metadata=mode:draft -c ../book.css $< -o $@
 
 onepage/%-quicklink.html: book/%.md book/quicklink.html book/filter.lua disabled.conf
 	mkdir -p $(dir $@)
-	pandoc --toc --template book/quicklink.html $(FLAGS) --variable=script:feedback.js $(PANDOC_COMMON_ARGS) $< -o $@
+	pandoc --toc --template book/quicklink.html $(FLAGS) ${SCRIPTS} $(PANDOC_COMMON_ARGS) $< -o $@
 
 www/draft/onepage.html: $(patsubst book/%.md,onepage/%.html,$(wildcard book/*.md)) $(patsubst book/%.md,onepage/%-quicklink.html,$(wildcard book/*.md)) book/onepage-head.html
 	mkdir -p $(dir $@)
@@ -22,7 +23,7 @@ www/draft/onepage.html: $(patsubst book/%.md,onepage/%.html,$(wildcard book/*.md
 
 www/%.html: book/%.md book/template.html book/signup.html book/filter.lua disabled.conf
 	mkdir -p $(dir $@)
-	pandoc --toc --template book/template.html $(FLAGS) -c book.css --variable=script:feedback.js $(PANDOC_COMMON_ARGS) $< -o $@
+	pandoc --toc --template book/template.html $(FLAGS) -c book.css ${SCRIPTS} $(PANDOC_COMMON_ARGS) $< -o $@
 
 www/blog/%.html: blog/%.md book/template.html book/filter.lua disabled.conf
 	mkdir -p $(dir $@)
@@ -31,7 +32,7 @@ www/blog/%.html: blog/%.md book/template.html book/filter.lua disabled.conf
 www/draft/%.html: book/%.md book/template.html book/signup.html book/filter.lua
 	@ mkdir -p $(dir $@)
 	pandoc --toc --template book/template.html $(FLAGS) \
-	       --metadata=mode:draft --variable=script:../feedback.js \
+	       --metadata=mode:draft ${SCRIPTS} \
                -c ../book.css $(PANDOC_COMMON_ARGS) \
                $< -o $@
 

--- a/www/book.css
+++ b/www/book.css
@@ -90,9 +90,10 @@ nav#toc { display: none; }
 .main nav#toc { display: none; }
 
 body { counter-reset: fn; }
-.note-container { counter-increment: fn; white-space: pre; }
+.note-container { counter-increment: fn; white-space: pre; cursor: pointer; }
 .note-container:after { content: "]"; color: #a86; }
-.note-container:before { content: " ["; color: #a86; }
+.note-container:before { content: " [" counter(fn); color: #a86; }
+.note-container.open:before { content: " ["; color: #a86; }
 .note { font-style: italic; white-space: normal; color: #a86; }
 @media only screen and (min-width: 1150px) {
     body { width: 65ex; padding: 0 17ex 0 0; }
@@ -102,12 +103,20 @@ body { counter-reset: fn; }
         font-size: 110%; vertical-align: reset; text-align: left; color: currentColor;
     }
     div .note { margin-right: calc(-28ex - 1rem - 2px); }
-    .note-container { font-size: 60%; vertical-align: super; }
-    .note-container:before { content: "[" counter(fn); }
+    .note-container { font-size: 60%; vertical-align: super; cursor: auto; }
+    .note-container.open:before { content: " [" counter(fn); color: #a86; }
     .note:before { content: counter(fn) ". "; }
 }
 @media only screen and (min-width: 1350px) {
     body { padding: 0 17ex; }
+}
+@media only screen and (max-width: 1149px) {
+  .note {
+    display: none;
+  }
+  .open .note {
+    display: inline; 
+  }
 }
 
 .todo, .quirk, .warning, .installation, .further { padding: 1em 1em 0; margin: 1em 0; }

--- a/www/book.js
+++ b/www/book.js
@@ -1,0 +1,16 @@
+// Add click handlers to open and close inline notes on small screens.
+// Notes start out closed.
+function addNoteOpeners() {
+	for (let note_container of document.querySelectorAll(".note-container")) {
+		note_container.addEventListener("click", (event) => {
+			let classes = note_container.classList;
+			if (!classes.contains("open"))
+				classes.add("open");
+			else
+				classes.remove("open");
+			event.preventDefault();
+		});
+	}
+}
+
+window.addEventListener("load", addNoteOpeners);


### PR DESCRIPTION
This makes it much easier to read the book on those devices. Tapping on the footnote number will open it; tapping again
will close it again.