### PR TITLE
Bugfixes in labs

### DIFF
--- a/book/html.md
+++ b/book/html.md
@@ -211,7 +211,7 @@ This is *almost* a complete parser, but it doesn't quite work at the
 beginning and end of the document. The very first open tag is an edge
 case without a parent:
 
-``` {.python}
+``` {.python indent=4}
 def add_tag(self, tag):
     # ...
     else:
@@ -557,7 +557,7 @@ class Layout:
 Now we need the `Layout` object to walk the node tree, calling `open`,
 `close`, and `text` in the right order:
 
-``` {.python}
+``` {.python indent=4}
 def recurse(self, tree):
     if isinstance(tree, Text):
         self.text(tree.text)

--- a/src/lab3.py
+++ b/src/lab3.py
@@ -14,7 +14,15 @@ def request(url):
     assert scheme in ["http", "https"], \
         "Unknown scheme {}".format(scheme)
 
-    host, path = url.split("/", 1)
+    host = ""
+    path = ""
+    if (url.find("/") >= 0):
+        host, path = url.split("/", 1)
+        print(host)
+    else:
+        host = url
+        print(host)
+
     path = "/" + path
     port = 80 if scheme == "http" else 443
 

--- a/src/lab3.py
+++ b/src/lab3.py
@@ -14,14 +14,10 @@ def request(url):
     assert scheme in ["http", "https"], \
         "Unknown scheme {}".format(scheme)
 
-    host = ""
-    path = ""
     if (url.find("/") >= 0):
         host, path = url.split("/", 1)
-        print(host)
     else:
-        host = url
-        print(host)
+        host, path = url, ""
 
     path = "/" + path
     port = 80 if scheme == "http" else 443

--- a/src/lab4.py
+++ b/src/lab4.py
@@ -14,7 +14,15 @@ def request(url):
     assert scheme in ["http", "https"], \
         "Unknown scheme {}".format(scheme)
 
-    host, path = url.split("/", 1)
+    host = ""
+    path = ""
+    if (url.find("/") >= 0):
+        host, path = url.split("/", 1)
+        print(host)
+    else:
+        host = url
+        print(host)
+
     path = "/" + path
     port = 80 if scheme == "http" else 443
 

--- a/src/lab4.py
+++ b/src/lab4.py
@@ -18,10 +18,8 @@ def request(url):
     path = ""
     if (url.find("/") >= 0):
         host, path = url.split("/", 1)
-        print(host)
     else:
         host = url
-        print(host)
 
     path = "/" + path
     port = 80 if scheme == "http" else 443

--- a/src/lab4.py
+++ b/src/lab4.py
@@ -14,12 +14,10 @@ def request(url):
     assert scheme in ["http", "https"], \
         "Unknown scheme {}".format(scheme)
 
-    host = ""
-    path = ""
     if (url.find("/") >= 0):
         host, path = url.split("/", 1)
     else:
-        host = url
+        host, path = url, ""
 
     path = "/" + path
     port = 80 if scheme == "http" else 443

--- a/src/lab5.py
+++ b/src/lab5.py
@@ -14,7 +14,15 @@ def request(url):
     assert scheme in ["http", "https"], \
         "Unknown scheme {}".format(scheme)
 
-    host, path = url.split("/", 1)
+    host = ""
+    path = ""
+    if (url.find("/") >= 0):
+        host, path = url.split("/", 1)
+        print(host)
+    else:
+        host = url
+        print(host)
+
     path = "/" + path
     port = 80 if scheme == "http" else 443
 

--- a/src/lab5.py
+++ b/src/lab5.py
@@ -18,10 +18,8 @@ def request(url):
     path = ""
     if (url.find("/") >= 0):
         host, path = url.split("/", 1)
-        print(host)
     else:
         host = url
-        print(host)
 
     path = "/" + path
     port = 80 if scheme == "http" else 443

--- a/src/lab5.py
+++ b/src/lab5.py
@@ -14,12 +14,10 @@ def request(url):
     assert scheme in ["http", "https"], \
         "Unknown scheme {}".format(scheme)
 
-    host = ""
-    path = ""
     if (url.find("/") >= 0):
         host, path = url.split("/", 1)
     else:
-        host = url
+        host, path = url, ""
 
     path = "/" + path
     port = 80 if scheme == "http" else 443

--- a/src/lab6.py
+++ b/src/lab6.py
@@ -18,10 +18,8 @@ def request(url):
     path = ""
     if (url.find("/") >= 0):
         host, path = url.split("/", 1)
-        print(host)
     else:
         host = url
-        print(host)
 
 
     path = "/" + path

--- a/src/lab6.py
+++ b/src/lab6.py
@@ -14,12 +14,10 @@ def request(url):
     assert scheme in ["http", "https"], \
         "Unknown scheme {}".format(scheme)
 
-    host = ""
-    path = ""
     if (url.find("/") >= 0):
         host, path = url.split("/", 1)
     else:
-        host = url
+        host, path = url, ""
 
 
     path = "/" + path

--- a/src/lab6.py
+++ b/src/lab6.py
@@ -150,7 +150,7 @@ def parse(tokens):
             if not currently_open: return node
             currently_open[-1].children.append(node)
         elif tok.tag in SELF_CLOSING_TAGS:
-            node = ElementNode(tok.tag, tok.attributes, parent)
+            node = ElementNode(tok.tag, parent, tok.attributes)
             parent.children.append(node)
         elif tok.tag.startswith("!"):
             continue

--- a/src/lab6.py
+++ b/src/lab6.py
@@ -14,7 +14,16 @@ def request(url):
     assert scheme in ["http", "https"], \
         "Unknown scheme {}".format(scheme)
 
-    host, path = url.split("/", 1)
+    host = ""
+    path = ""
+    if (url.find("/") >= 0):
+        host, path = url.split("/", 1)
+        print(host)
+    else:
+        host = url
+        print(host)
+
+
     path = "/" + path
     port = 80 if scheme == "http" else 443
 

--- a/src/lab7.py
+++ b/src/lab7.py
@@ -18,10 +18,8 @@ def request(url):
     path = ""
     if (url.find("/") >= 0):
         host, path = url.split("/", 1)
-        print(host)
     else:
         host = url
-        print(host)
 
     path = "/" + path
     port = 80 if scheme == "http" else 443

--- a/src/lab7.py
+++ b/src/lab7.py
@@ -14,12 +14,10 @@ def request(url):
     assert scheme in ["http", "https"], \
         "Unknown scheme {}".format(scheme)
 
-    host = ""
-    path = ""
     if (url.find("/") >= 0):
         host, path = url.split("/", 1)
     else:
-        host = url
+        host, path = url, ""
 
     path = "/" + path
     port = 80 if scheme == "http" else 443

--- a/src/lab7.py
+++ b/src/lab7.py
@@ -14,7 +14,15 @@ def request(url):
     assert scheme in ["http", "https"], \
         "Unknown scheme {}".format(scheme)
 
-    host, path = url.split("/", 1)
+    host = ""
+    path = ""
+    if (url.find("/") >= 0):
+        host, path = url.split("/", 1)
+        print(host)
+    else:
+        host = url
+        print(host)
+
     path = "/" + path
     port = 80 if scheme == "http" else 443
 
@@ -145,7 +153,10 @@ def parse(tokens):
             continue
         else:
             node = ElementNode(tok.tag, tok.attributes)
-            node.parent = currently_open[-1]
+            if len(currently_open) > 0:
+                node.parent = currently_open[-1]
+            else:
+                node.parent = None
             currently_open.append(node)
     while currently_open:
         node = currently_open.pop()

--- a/src/lab8.py
+++ b/src/lab8.py
@@ -14,7 +14,15 @@ def request(url, payload=None):
     assert scheme in ["http", "https"], \
         "Unknown scheme {}".format(scheme)
 
-    host, path = url.split("/", 1)
+    host = ""
+    path = ""
+    if (url.find("/") >= 0):
+        host, path = url.split("/", 1)
+        print(host)
+    else:
+        host = url
+        print(host)
+
     path = "/" + path
     port = 80 if scheme == "http" else 443
 
@@ -152,7 +160,10 @@ def parse(tokens):
             continue
         else:
             node = ElementNode(tok.tag, tok.attributes)
-            node.parent = currently_open[-1]
+            if len(currently_open) > 0:
+                node.parent = currently_open[-1]
+            else:
+                node.parent = None
             currently_open.append(node)
     while currently_open:
         node = currently_open.pop()

--- a/src/lab8.py
+++ b/src/lab8.py
@@ -18,10 +18,8 @@ def request(url, payload=None):
     path = ""
     if (url.find("/") >= 0):
         host, path = url.split("/", 1)
-        print(host)
     else:
         host = url
-        print(host)
 
     path = "/" + path
     port = 80 if scheme == "http" else 443

--- a/src/lab8.py
+++ b/src/lab8.py
@@ -14,12 +14,10 @@ def request(url, payload=None):
     assert scheme in ["http", "https"], \
         "Unknown scheme {}".format(scheme)
 
-    host = ""
-    path = ""
     if (url.find("/") >= 0):
         host, path = url.split("/", 1)
     else:
-        host = url
+        host, path = url, ""
 
     path = "/" + path
     port = 80 if scheme == "http" else 443

--- a/src/lab9.py
+++ b/src/lab9.py
@@ -15,7 +15,15 @@ def request(url, payload=None):
     assert scheme in ["http", "https"], \
         "Unknown scheme {}".format(scheme)
 
-    host, path = url.split("/", 1)
+    host = ""
+    path = ""
+    if (url.find("/") >= 0):
+        host, path = url.split("/", 1)
+        print(host)
+    else:
+        host = url
+        print(host)
+
     path = "/" + path
     port = 80 if scheme == "http" else 443
 
@@ -153,7 +161,10 @@ def parse(tokens):
             continue
         else:
             node = ElementNode(tok.tag, tok.attributes)
-            node.parent = currently_open[-1]
+            if len(currently_open) > 0:
+                node.parent = currently_open[-1]
+            else:
+                node.parent = None
             currently_open.append(node)
     while currently_open:
         node = currently_open.pop()
@@ -773,7 +784,8 @@ class Browser:
 
         self.setup_js()
         for script in find_scripts(self.nodes, []):
-            header, body = request(relative_url(script, self.history[-1]))
+            url = relative_url(script, self.history[-1])
+            header, body = request(url)
             try:
                 print("Script returned: ", self.js.evaljs(body))
             except dukpy.JSRuntimeError as e:
@@ -801,7 +813,9 @@ class Browser:
         return elt.attributes.get(attr, None)
 
     def js_innerHTML(self, handle, s):
-        doc = parse(lex("<html><body>" + s + "</body></html>"))
+        whole_str = "<html><body>" + s + "</body></html>"
+        lexed = lex(whole_str)
+        doc = parse(lexed)
         new_nodes = doc.children[0].children
         elt = self.handle_to_node[handle]
         elt.children = new_nodes

--- a/src/lab9.py
+++ b/src/lab9.py
@@ -777,7 +777,7 @@ class Browser:
 
         for link in find_links(self.nodes, []):
             header, body = request(relative_url(link, url))
-            self.rules.extend(CSSParser(body).parse())
+            self4.rules.extend(CSSParser(body).parse())
 
         self.rules.sort(key=lambda x: x[0].priority())
         self.rules.reverse()
@@ -812,9 +812,7 @@ class Browser:
         return elt.attributes.get(attr, None)
 
     def js_innerHTML(self, handle, s):
-        whole_str = "<html><body>" + s + "</body></html>"
-        lexed = lex(whole_str)
-        doc = parse(lexed)
+        doc = parse(lex("<html><body>" + s + "</body></html>"))
         new_nodes = doc.children[0].children
         elt = self.handle_to_node[handle]
         elt.children = new_nodes

--- a/src/lab9.py
+++ b/src/lab9.py
@@ -784,8 +784,7 @@ class Browser:
 
         self.setup_js()
         for script in find_scripts(self.nodes, []):
-            url = relative_url(script, self.history[-1])
-            header, body = request(url)
+            header, body = request(relative_url(script, self.history[-1]))
             try:
                 print("Script returned: ", self.js.evaljs(body))
             except dukpy.JSRuntimeError as e:

--- a/src/lab9.py
+++ b/src/lab9.py
@@ -19,10 +19,8 @@ def request(url, payload=None):
     path = ""
     if (url.find("/") >= 0):
         host, path = url.split("/", 1)
-        print(host)
     else:
         host = url
-        print(host)
 
     path = "/" + path
     port = 80 if scheme == "http" else 443

--- a/src/runtime9.js
+++ b/src/runtime9.js
@@ -7,7 +7,7 @@ document = { querySelectorAll: function(s) {
 
 function Node(handle) { this.handle = handle; }
 Node.prototype.getAttribute = function(attr) {
-    return call_python("getAttribute", self.handle, attr);
+    return call_python("getAttribute", this.handle, attr);
 }
 
 LISTENERS = {}

--- a/src/server9.py
+++ b/src/server9.py
@@ -58,7 +58,8 @@ def show_comments():
     out += "</form>"
     for entry in ENTRIES:
         out += "<p>" + entry + "</p>"
-    out += "<script src=/comment.js></script>"
+    out += "<div id=errors></div>"
+    out += "<script src=/comment9.js></script>"
     return out
 
 def add_entry(params):


### PR DESCRIPTION
1. Handle <html> elements not preceded by other tokens correctly; in these cases, currently_open will be an empty array
2. Handle URLs not containing a / after the domain
3. s/self/this/ in runtime9.js
4. Output "comment9.js" instead of "comment.js" in server9.js
5. Output the id=errors div in server9.js, which is expected by the script
6. Wrong order of arguments to ElementNode constructor in lab6.py