### PR TITLE
Fix href attribute for sequential link elements

### DIFF
--- a/book/template.html
+++ b/book/template.html
@@ -5,8 +5,8 @@
   <meta name="generator" content="pandoc" />
   <meta name="viewport" content="width=device-width,initial-scale=1.0,user-scalable=yes" />
 $for(author-meta)$  <meta name="author" content="$author-meta$" />$endfor$
-$if(prev)$  <link rel="prev" href="$prev$" />$endif$
-$if(next)$  <link rel="next" href="$next$" />$endif$
+$if(prev)$  <link rel="prev" href="$prev$.html" />$endif$
+$if(next)$  <link rel="next" href="$next$.html" />$endif$
 $for(css)$  <link rel="stylesheet" href="$css$" />$endfor$
   <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Vollkorn%7CLora&display=swap" />
   <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Vollkorn:400i%7CLora:400i&display=swap" />


### PR DESCRIPTION
I use a browser extension (Tridactyl) that makes it easy to navigate backwards and forwards using the URLs specified by `<link>` elements. This commit add the `.html` suffix for `href `attributes of external resource links when the relationship indicates sequential access, i.e., “prev”, “next”.