### PR TITLE
New style for widgets with pop-up input controls

### DIFF
--- a/book/graphics.md
+++ b/book/graphics.md
@@ -271,8 +271,7 @@ The code increases `cursor_y` and resets `cursor_x`[^crlf] once
 `cursor_x` goes past 787 pixels.[^not-800] Wrapping the text this way
 makes it possible to read more than a single line:
 
-<iframe class="widget" src="widgets/lab2-render.html"
-    height=160 data-big-height=160 data-small-height=320></iframe>
+<iframe class="widget" src="widgets/lab2-render.html" height=204></iframe>
 
 [^crlf]: In the olden days of type writers, increasing *y* meant
     *feed*ing in a new *line*, and resetting *x* meant *return*ing the

--- a/book/layout.md
+++ b/book/layout.md
@@ -381,6 +381,8 @@ run into the very edge of the window and get cut off.
 For all three types of layout object, the order of the steps in the
 `layout` method should be the same:
 
+<iframe class="widget" src="widgets/lab5-propagate.html" height=204></iframe>
+
 + When `layout` is called, it first creates a child layout object for
   each child element.
 + Then, `layout` computes the `width`, `x`, and `y` fields, reading from the

--- a/book/text.md
+++ b/book/text.md
@@ -643,6 +643,10 @@ This new `flush` function has three responsibilities:
 2. It must add all those words to the display list; and
 3. It must update the `cursor_x` and `cursor_y` fields
 
+Here's what it looks like, step by step:
+
+<iframe class="widget" src="widgets/lab3-baselines.html" height=204></iframe>
+
 Since we want words to line up "on the line", let's start by computing
 where that line should be. That depends on the metrics for all the
 fonts involved:

--- a/www/book.css
+++ b/www/book.css
@@ -138,7 +138,7 @@ figure img { width: 100%; }
 .installation:before { content: "Installation"; color: blue; }
 .further { border: 2px solid green; padding-top: 0; }
 .further > :first-child:before { content: "Go further: "; font-weight: bold; color: green; }
-.widget { width: 100%; border: 2px solid gray; }
+.widget { width: 100%; border: 2px solid steelblue; }
 
 code .st { color: #666; }
 code .cf, code .kw, code .im { color: #606; }

--- a/www/widgets/lab2-render.html
+++ b/www/widgets/lab2-render.html
@@ -1,17 +1,21 @@
 <!doctype html>
 <meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
 <link rel="stylesheet" href="widget.css" />
 
 <figure id="widget">
   <canvas id="canvas" width="352" height="160"></canvas>
-  <div id="controls">
-  <div id="step-controls">
-    <button class="reset" disabled>Restart</button>
-    <button class="stepb" disabled>Back</button>
-    <button class="stepf">Next</button>
-    <button class="play">Animate</button>
-  </div>
-  <textarea id="input" rows="4">第一回 灵根育孕源流出 心性修持大道生</textarea>
+  <form id="controls">
+    <fieldset id="step-controls">
+      <h1>Character-by-character Rendering</h1>
+      <button class="reset left" disabled>Restart</button>
+      <button class="stepb left" disabled>Back</button>
+      <button class="stepf right">Next</button>
+      <button class="play right">Animate</button>
+    </fieldset>
+    <fieldset id="input-controls">
+      <textarea id="input" rows="4">第一回 灵根育孕源流出 心性修持大道生</textarea>
+    </fieldset>
   </div>
 </figure>
 

--- a/www/widgets/lab3-baselines.html
+++ b/www/widgets/lab3-baselines.html
@@ -1,6 +1,8 @@
 <!doctype html>
 <meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
 <link rel="stylesheet" href="widget.css" />
+
 <style>
 text.drawn { dominant-baseline: text-before-edge; }
 /* This nasty hack corrects for some weird difference in Chrome */
@@ -14,19 +16,24 @@ line.baseline { stroke-dasharray: 5, 5; }
 .amax { fill: darkred; }
 .dreg { fill: lightblue; }
 .dmax { fill: darkblue; }
+line.areg { stroke: darkred; }
+line.dreg { stroke: darkblue; }
 </style>
 
 <figure id="widget">
   <svg id="canvas" width="352" height="160" viewBox="0 0 352 160"></svg>
-  <div id="controls">
-  <div id="step-controls">
-    <button class="reset" disabled>Restart</button>
-    <button class="stepb" disabled>Back</button>
-    <button class="stepf">Next</button>
-    <button class="play">Animate</button>
-  </div>
-  <textarea id="input" rows="4">Mixed <big>big</big> and <small>small</small></textarea>
-  </div>
+  <form id="controls">
+    <fieldset id="step-controls">
+      <h1>Aligning the words on a line</h1>
+      <button class="reset left" disabled>Restart</button>
+      <button class="stepb left" disabled>Back</button>
+      <button class="stepf right">Next</button>
+      <button class="play right">Animate</button>
+    </fieldset>
+    <fieldset id="input-controls">
+      <textarea id="input" rows="4">Mixed <big>big</big> and <small>small</small></textarea>
+    </fieldset>
+  </form>
 </figure>
 
 <script src="lab3.js"></script>
@@ -97,18 +104,30 @@ function draw_widget() {
             x2: "100%", y2: b,
             class: "baseline",
         }));
+        let h = STATE.max_asc * ZOOM;
         elt.appendChild(svg("rect", {
-            x: margin - 5, y: y1,
-            width: 5, height: b - y1,
+            x: margin - 5, y: b - h,
+            width: 5, height: h,
             class: "amax",
-        }))
+        }));
+        elt.appendChild(svg("line", {
+            x1: margin-2.5, y1: y1,
+            x2: margin-2.5, y2: b - h,
+            class: "areg",
+        }));
     }
     if (STATE.max_desc) {
+        let h = STATE.max_desc * ZOOM;
         elt.appendChild(svg("rect", {
             x: margin - 5, y: b,
-            width: 5, height: 1.2 * STATE.max_desc * ZOOM,
+            width: 5, height: h,
             class: "dmax",
-        }))
+        }));
+        elt.appendChild(svg("line", {
+            x1: margin-2.5, y1: b + h,
+            x2: margin-2.5, y2: b + h * 1.2,
+            class: "dreg",
+        }));
     }
 
     if (STATE.line) {

--- a/www/widgets/lab5-propagate.html
+++ b/www/widgets/lab5-propagate.html
@@ -1,17 +1,24 @@
 <!doctype html>
 <meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
 <link rel="stylesheet" href="widget.css" />
+
+<style>
+#output { margin: 0 1ex; }
+</style>
 
 <figure id="widget">
   <pre id="output" style="width: 352px; height: 160px;"></pre>
-  <div id="controls">
-  <div id="step-controls">
-    <button class="reset" disabled>Restart</button>
-    <button class="stepb" disabled>Back</button>
-    <button class="stepf">Next</button>
-    <button class="play">Animate</button>
-  </div>
-  <textarea id="input" rows="4"><html>
+  <form id="controls">
+    <fieldset id="step-controls">
+      <h1>Computing sizes and positions</h1>
+      <button class="reset left" disabled>Restart</button>
+      <button class="stepb left" disabled>Back</button>
+      <button class="stepf right">Next</button>
+      <button class="play right">Animate</button>
+    </fieldset>
+    <fieldset id="input-controls">
+      <textarea id="input" rows="4"><html>
   <body>
     <h1>Header</h1>
     <p>Text 1</p>
@@ -19,7 +26,8 @@
     <p>Text 3</p>
   </body>
 </html></textarea>
-  </div>
+    </fieldset>
+  </form>
 </figure>
 
 <script src="lab5.js"></script>
@@ -58,7 +66,7 @@ function tree_to_str(node, indent, current, status) {
     for (let field of ["x", "y", "width", "height"]) {
         if (!node[field]) continue;
         if (fields) s += ",";
-        s += " " + field + "=" + node[field];
+        s += " " + field + "=" + Math.round(node[field] * 10) / 10;
         fields++;
     }
     s += " }";

--- a/www/widgets/rt.js
+++ b/www/widgets/rt.js
@@ -205,7 +205,7 @@ class Widget {
             back: elt.querySelector(".stepb"),
             next: elt.querySelector(".stepf"),
             animate: elt.querySelector(".play"),
-            input: elt.querySelector("textarea"),
+            input: elt.querySelector("#input-controls"),
         };
 
         if (this.controls.reset) this.controls.reset.addEventListener("click", this.reset.bind(this));
@@ -225,6 +225,7 @@ class Widget {
         breakpoint.capture(evt, function(...args) {
             return new Promise(function (resolve) {
                 that.step += 1;
+                that.controls.back.disabled = (that.step <= 0);
                 if (cb) cb(...args);
                 if (that.step < that.stop && that.stop >= 0) {
                     resolve();
@@ -247,7 +248,8 @@ class Widget {
         return this;
     }
 
-    reset() {
+    reset(e) {
+        this.elt.classList.remove("running");
         this.step = -1;
         this.k = this.runner;
         if (this.timer) clearInterval(this.timer);
@@ -257,24 +259,32 @@ class Widget {
         this.controls.input.disabled = false;
         this.controls.next.disabled = false;
         this.controls.animate.disabled = false;
+        this.controls.next.textContent = "Start";
+        if (e) e.preventDefault();
     }
 
-    back() {
+    back(e) {
         this.stop = this.step - 1;
         this.reset();
         this.next();
+        if (e) e.preventDefault();
     }
 
-    next() {
+    next(e) {
+        this.elt.classList.add("running");
         console.assert(this.k, "Tried to step forward but no next state available");
+        this.controls.next.textContent = "Next";
         this.controls.input.disabled = true;
         this.controls.reset.disabled = false;
         this.controls.back.disabled = false;
         this.k();
+        if (e) e.preventDefault();
     }
 
-    animate() {
+    animate(e) {
         this.timer = setInterval(this.next.bind(this), 250);
+        this.next();
+        if (e) e.preventDefault();
     }
 
   

--- a/www/widgets/widget.css
+++ b/www/widgets/widget.css
@@ -1,19 +1,35 @@
 html, body, figure { margin: 0; padding: 0; height: 100%; }
-figure { width: 100%; display: flex; align-items: start; }
-@media (max-width: 600px) { figure { flex-direction: column; align-items: center; }}
-#controls { margin: 0; background: gray; padding: .5em; flex-grow: 1; align-self: stretch; }
-#step-controls { margin-bottom: 1em; text-align: center; }
-#step-controls button {
-    min-width: 2em; height: 2em; background: lightgray; border: 0; border-radius: 1em;
+figure { width: 100%; }
+#controls {
+    box-sizing: border-box; margin: 0; padding: .5em .5em 0;
+    background: #e5f7ff; border-top: 2px solid steelblue;
 }
-#step-controls button[disabled] { background: darkgray; }
-textarea {
-    box-model: border-box;
-    border: 0;
-    width: 100%;
-    display: block;
-    font-size: 120%;
+fieldset { border: none; margin: 0; padding: 0; }
+#input-controls { margin: .5em 0; }
+
+#controls { position: absolute; left: 0; right: 0; bottom: 0; overflow: hidden; }
+@media (max-height: 400px) {
+  #input-controls { transition: all .3s ease; max-height: 160px; }
+  .running #input-controls { max-height: 0; margin: .5em 0 0; }
 }
-textarea[disabled] {
-    background: darkgray;
+
+#step-controls { display: flex; gap: 1ex; font-size: 20px; }
+#step-controls h1 {
+    flex-grow: 1; order: 3; text-align: center;
+    font: 100% sans; margin: 0; line-height: 1.33em;
 }
+#step-controls .left { order: 1; }
+#step-controls .right { order: 5; }
+@media (max-width: 600px) { #step-controls { font-size: 16px; } }
+@media (max-width: 400px) { #step-controls { flex-wrap: wrap; } }
+#step-controls button { font: 70% sans-serif; min-width: 2em; height: 2em; border-radius: 1em; }
+
+textarea { box-sizing: border-box; width: 100%; font: 20px monospace; }
+
+#step-controls button:hover { cursor: pointer; }
+#step-controls button:hover, textarea:focus { border: 2px solid blue; }
+#step-controls button, textarea { border: 2px solid steelblue; background: transparent; }
+#step-controls button:disabled, textarea:disabled {
+    background: #cdecfa; border-color: #cdecfa; cursor: default; }
+
+#input-controls button { float: right; }


### PR DESCRIPTION
This adds a pop-up control bar, and I put a little bit of effort into styling:

<img width="574" alt="Screen Shot 2021-04-27 at 3 27 02 PM" src="https://user-images.githubusercontent.com/30707/116300570-08739b00-a76d-11eb-82fb-36d0f792422b.png">

A few advantages:
- The input field is hidden, not just disabled (less user confusion)
- More horizontal room (can add explanatory text)
- The "Restart" button now does something obvious (open the input box back up)