### PR TITLE
Restyle widgets

### DIFF
--- a/www/book.css
+++ b/www/book.css
@@ -140,7 +140,7 @@ figure img { width: 100%; }
 .installation:before { content: "Installation"; color: blue; }
 .further { border: 2px solid green; padding-top: 0; }
 .further > :first-child:before { content: "Go further: "; font-weight: bold; color: green; }
-.widget { width: 100%; border: 2px solid steelblue; }
+.widget { width: 100%; border: 2px solid navy; }
 
 code .st { color: #666; }
 code .cf, code .kw, code .im { color: #606; }

--- a/www/widgets/lab2-render.html
+++ b/www/widgets/lab2-render.html
@@ -3,20 +3,20 @@
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <link rel="stylesheet" href="widget.css" />
 
+<form id="controls">
+  <fieldset id="step-controls">
+    <h1>Character-by-character Rendering</h1>
+    <button class="reset left" disabled><span>Restart</span></button>
+    <button class="stepb left" disabled><span>Back</span></button>
+    <button class="stepf right"><span>Next</span></button>
+    <button class="play right"><span>Animate</span></button>
+  </fieldset>
+  <fieldset id="input-controls">
+    <textarea id="input" rows="4">第一回 灵根育孕源流出 心性修持大道生</textarea>
+  </fieldset>
+</div>
 <figure id="widget">
   <canvas id="canvas" width="352" height="160"></canvas>
-  <form id="controls">
-    <fieldset id="step-controls">
-      <h1>Character-by-character Rendering</h1>
-      <button class="reset left" disabled><span>Restart</span></button>
-      <button class="stepb left" disabled><span>Back</span></button>
-      <button class="stepf right"><span>Next</span></button>
-      <button class="play right"><span>Animate</span></button>
-    </fieldset>
-    <fieldset id="input-controls">
-      <textarea id="input" rows="4">第一回 灵根育孕源流出 心性修持大道生</textarea>
-    </fieldset>
-  </div>
 </figure>
 
 <script src="lab2.js"></script>
@@ -26,7 +26,7 @@ const socket = lib.socket({ "http://input/": http_textarea(document.querySelecto
 const ssl = lib.ssl();
 const tkinter = lib.tkinter({ canvas: document.querySelector("#canvas"), zoom: 2.0 });
 
-let widget = new Widget(document.querySelector("#widget"));
+let widget = new Widget(document.querySelector("#controls"));
 widget.pause("render");
 widget.run(async function() {
     WIDTH = 16 * 11;

--- a/www/widgets/lab2-render.html
+++ b/www/widgets/lab2-render.html
@@ -8,10 +8,10 @@
   <form id="controls">
     <fieldset id="step-controls">
       <h1>Character-by-character Rendering</h1>
-      <button class="reset left" disabled>Restart</button>
-      <button class="stepb left" disabled>Back</button>
-      <button class="stepf right">Next</button>
-      <button class="play right">Animate</button>
+      <button class="reset left" disabled><span>Restart</span></button>
+      <button class="stepb left" disabled><span>Back</span></button>
+      <button class="stepf right"><span>Next</span></button>
+      <button class="play right"><span>Animate</span></button>
     </fieldset>
     <fieldset id="input-controls">
       <textarea id="input" rows="4">第一回 灵根育孕源流出 心性修持大道生</textarea>

--- a/www/widgets/lab3-baselines.html
+++ b/www/widgets/lab3-baselines.html
@@ -4,6 +4,13 @@
 <link rel="stylesheet" href="widget.css" />
 
 <style>
+figure { display: flex; flex-wrap: wrap; justify-content: space-between; }
+#phases {
+    flex: 1; flex-basis: 300px;
+    display: flex; flex-wrap: wrap; justify-content: space-between;
+}
+#phases:after { content: ""; } /* Adds an extra gap */
+
 text.drawn { dominant-baseline: text-before-edge; }
 /* This nasty hack corrects for some weird difference in Chrome */
 @media screen and (-webkit-min-device-pixel-ratio:0) and (min-resolution:.001dpcm) {
@@ -18,17 +25,8 @@ line.baseline { stroke-dasharray: 5, 5; }
 .amax { fill: darkred; stroke: darkred; }
 .dreg { fill: lightblue; stroke: lightblue; }
 .dmax { fill: darkblue; stroke: darkblue }
-svg { width: 100%; }
-#g1 { transform: translate(50px, 0); }
-#g2 { transform: translate(400px, 0); }
-#caption { transform: translate(670px, 0); }
-@media screen and (max-width: 750px) {
-    #g1 { transform: translate(80px, -10px); }
-    #g2 { transform: translate(80px, 60px); }
-    #caption { transform: translate(400px, 0); }
-    #g1 text.title { transform: translate(-70px, 10px); }
-    #g2 text.title { transform: translate(-70px, 10px); }
-}
+#g1 { transform: translate(80px, 0); }
+#g2 { transform: translate(80px, 0); }
 </style>
 
 <form id="controls">
@@ -44,30 +42,34 @@ svg { width: 100%; }
   </fieldset>
 </form>
 <figure id="widget">
-  <svg id="canvas" height="160">
-    <g id="g1"></g>
-    <g id="g2"></g>
-    <g id="caption">
-      <text x="0" y="20" class="title">Caption</text>
+  <div id="phases">
+    <svg width="300" height="100">
+      <g id="g1"></g>
+    </svg>
+    <svg width="300" height="120">
+      <g id="g2"></g>
+    </svg>
+  </div>
+  <svg width="100" height="160" id="caption">
+    <text x="0" y="20" class="title">Caption</text>
 
-      <g>
-        <rect x="2.5" y="70" width="5" height="30" class="areg"></rect>
-        <rect x="2.5" y="100" width="5" height="20" class="dreg"></rect>
-      </g>
+    <g>
+      <rect x="2.5" y="70" width="5" height="30" class="areg"></rect>
+      <rect x="2.5" y="100" width="5" height="20" class="dreg"></rect>
+    </g>
 
-      <g transform="translate(10 0)">
-        <line x1="5" y1="50" x2="5" y2="70" class="amax"></line>
-        <rect x="2.5" y="70" width="5" height="30" class="amax"></rect>
-        <rect x="2.5" y="100" width="5" height="20" class="dmax"></rect>
-        <line x1="5" y1="120" x2="5" y2="140" class="dmax"></line>
-      </g>
+    <g transform="translate(10 0)">
+      <line x1="5" y1="50" x2="5" y2="70" class="amax"></line>
+      <rect x="2.5" y="70" width="5" height="30" class="amax"></rect>
+      <rect x="2.5" y="100" width="5" height="20" class="dmax"></rect>
+      <line x1="5" y1="120" x2="5" y2="140" class="dmax"></line>
+    </g>
 
-      <g transform="translate(25 0)">
-        <text x="0" y="65" class="label">Leading</text>
-        <text x="0" y="90" class="label">Ascent</text>
-        <text x="0" y="115" class="label">Descent</text>
-        <text x="0" y="135" class="label">Leading</text>
-      </g>
+    <g transform="translate(25 0)">
+      <text x="0" y="65" class="label">Leading</text>
+      <text x="0" y="90" class="label">Ascent</text>
+      <text x="0" y="115" class="label">Descent</text>
+      <text x="0" y="135" class="label">Leading</text>
     </g>
   </svg>
 </figure>
@@ -112,14 +114,14 @@ function draw_widget() {
     while (g1.children.length) g1.removeChild(g1.children[0]);
     while (g2.children.length) g2.removeChild(g2.children[0]);
 
-    let width = 250;
-    let tmargin = 50;
+    let width = 220;
+    let tmargin = 30;
     let y1 = tmargin;
     let b = y1 + 1.2 * STATE.max_asc * ZOOM;
     let y2 = y1 + ZOOM * (STATE.final_y - STATE.initial_y);
 
     if (STATE.initial_y || STATE.final_y) {
-        g2.appendChild(svg("text", { x: 0, y: tmargin - 30, class: "title" }, "Phase 2"));
+        g2.appendChild(svg("text", { x: 0, y: 20, class: "title" }, "Phase 2"));
         let y = STATE.final_y ? y2 : y1;
         g2.appendChild(svg("text", { x: 0, y: y, class: "varname" }, "cursor_y"));
     }
@@ -171,7 +173,7 @@ function draw_widget() {
     }
 
     if (STATE.line) {
-        g1.appendChild(svg("text", { x: 0, y: tmargin - 30, class: "title" }, "Phase 1"));
+        g1.appendChild(svg("text", { x: 0, y: 20, class: "title" }, "Phase 1"));
         g1.appendChild(svg("text", { x: 0, y: tmargin, class: "varname" }, "line"));
         g1.appendChild(svg("line", { x1: 0, y1: tmargin, x2: width, y2: tmargin }));
         for (let [x, word, font] of STATE.line) {

--- a/www/widgets/lab3-baselines.html
+++ b/www/widgets/lab3-baselines.html
@@ -61,10 +61,10 @@ svg { width: 100%; }
   <form id="controls">
     <fieldset id="step-controls">
       <h1>Aligning the words on a line</h1>
-      <button class="reset left" disabled>Restart</button>
-      <button class="stepb left" disabled>Back</button>
-      <button class="stepf right">Next</button>
-      <button class="play right">Animate</button>
+      <button class="reset left" disabled><span>Restart</span></button>
+      <button class="stepb left" disabled><span>Back</span></button>
+      <button class="stepf right"><span>Next</span></button>
+      <button class="play right"><span>Animate</span></button>
     </fieldset>
     <fieldset id="input-controls">
       <textarea id="input" rows="4">Mixed <big>big</big> and <small>small</small></textarea>

--- a/www/widgets/lab3-baselines.html
+++ b/www/widgets/lab3-baselines.html
@@ -31,6 +31,18 @@ svg { width: 100%; }
 }
 </style>
 
+<form id="controls">
+  <fieldset id="step-controls">
+    <h1>Aligning the words on a line</h1>
+    <button class="reset left" disabled><span>Restart</span></button>
+    <button class="stepb left" disabled><span>Back</span></button>
+    <button class="stepf right"><span>Next</span></button>
+    <button class="play right"><span>Animate</span></button>
+  </fieldset>
+  <fieldset id="input-controls">
+    <textarea id="input" rows="4">Mixed <big>big</big> and <small>small</small></textarea>
+  </fieldset>
+</form>
 <figure id="widget">
   <svg id="canvas" height="160">
     <g id="g1"></g>
@@ -58,18 +70,6 @@ svg { width: 100%; }
       </g>
     </g>
   </svg>
-  <form id="controls">
-    <fieldset id="step-controls">
-      <h1>Aligning the words on a line</h1>
-      <button class="reset left" disabled><span>Restart</span></button>
-      <button class="stepb left" disabled><span>Back</span></button>
-      <button class="stepf right"><span>Next</span></button>
-      <button class="play right"><span>Animate</span></button>
-    </fieldset>
-    <fieldset id="input-controls">
-      <textarea id="input" rows="4">Mixed <big>big</big> and <small>small</small></textarea>
-    </fieldset>
-  </form>
 </figure>
 
 <script src="lab3.js"></script>
@@ -82,7 +82,7 @@ const socket = lib.socket({ "http://input/": http_textarea(document.querySelecto
 const ssl = lib.ssl();
 const tkinter = lib.tkinter({ zoom: ZOOM });
 
-let widget = new Widget(document.querySelector("#widget"));
+let widget = new Widget(document.querySelector("#controls"));
   
 let STATE;
   

--- a/www/widgets/lab5-propagate.html
+++ b/www/widgets/lab5-propagate.html
@@ -12,10 +12,10 @@
   <form id="controls">
     <fieldset id="step-controls">
       <h1>Computing sizes and positions</h1>
-      <button class="reset left" disabled>Restart</button>
-      <button class="stepb left" disabled>Back</button>
-      <button class="stepf right">Next</button>
-      <button class="play right">Animate</button>
+      <button class="reset left" disabled><span>Restart</span></button>
+      <button class="stepb left" disabled><span>Back</span></button>
+      <button class="stepf right"><span>Next</span></button>
+      <button class="play right"><span>Animate</span></button>
     </fieldset>
     <fieldset id="input-controls">
       <textarea id="input" rows="4"><html>

--- a/www/widgets/lab5-propagate.html
+++ b/www/widgets/lab5-propagate.html
@@ -7,27 +7,26 @@
 #output { margin: 0 1ex; }
 </style>
 
+<form id="controls">
+  <fieldset id="step-controls">
+    <h1>Computing sizes and positions</h1>
+    <button class="reset left" disabled><span>Restart</span></button>
+    <button class="stepb left" disabled><span>Back</span></button>
+    <button class="stepf right"><span>Next</span></button>
+    <button class="play right"><span>Animate</span></button>
+  </fieldset>
+  <fieldset id="input-controls">
+    <textarea id="input" rows="4">
+<html><body>
+  <h1>Header</h1>
+  <p>Text 1</p>
+  <p>Text 2</p>
+  <p>Text 3</p>
+</body></html></textarea>
+  </fieldset>
+</form>
 <figure id="widget">
   <pre id="output" style="width: 352px; height: 160px;"></pre>
-  <form id="controls">
-    <fieldset id="step-controls">
-      <h1>Computing sizes and positions</h1>
-      <button class="reset left" disabled><span>Restart</span></button>
-      <button class="stepb left" disabled><span>Back</span></button>
-      <button class="stepf right"><span>Next</span></button>
-      <button class="play right"><span>Animate</span></button>
-    </fieldset>
-    <fieldset id="input-controls">
-      <textarea id="input" rows="4"><html>
-  <body>
-    <h1>Header</h1>
-    <p>Text 1</p>
-    <p>Text 2</p>
-    <p>Text 3</p>
-  </body>
-</html></textarea>
-    </fieldset>
-  </form>
 </figure>
 
 <script src="lab5.js"></script>
@@ -37,7 +36,7 @@ const socket = lib.socket({ "http://input/": http_textarea(document.querySelecto
 const ssl = lib.ssl();
 const tkinter = lib.tkinter({ zoom: 2.0 });
 
-let widget = new Widget(document.querySelector("#widget"));
+let widget = new Widget(document.querySelector("#controls"));
   
 function draw_tree(node, status) {
     let current = node;

--- a/www/widgets/rt.js
+++ b/www/widgets/rt.js
@@ -260,7 +260,7 @@ class Widget {
         this.controls.input.disabled = false;
         this.controls.next.disabled = false;
         this.controls.animate.disabled = false;
-        this.controls.next.textContent = "Start";
+        this.controls.next.children[0].textContent = "Start";
         if (e) e.preventDefault();
     }
 
@@ -280,7 +280,7 @@ class Widget {
     next(e) {
         this.elt.classList.add("running");
         console.assert(this.k, "Tried to step forward but no next state available");
-        this.controls.next.textContent = "Next";
+        this.controls.next.children[0].textContent = "Next";
         this.controls.input.disabled = true;
         this.controls.reset.disabled = false;
         this.controls.back.disabled = false;

--- a/www/widgets/widget.css
+++ b/www/widgets/widget.css
@@ -1,8 +1,8 @@
 html, body, #widget, fieldset { border: none; margin: 0; padding: 0; }
 #widget, #controls { width: 100%; }
 #controls {
-    box-sizing: border-box; margin: 0; padding: .5em;
-    background: #e5f7ff; border-bottom: 2px solid steelblue; font-size: 20px;
+    box-sizing: border-box; padding: .5em; font-size: 20px;
+    background: navy; color: white; z-index: 10;
 }
 
 #input-controls { margin: .5em 0 0; overflow: hidden; }
@@ -37,10 +37,11 @@ html, body, #widget, fieldset { border: none; margin: 0; padding: 0; }
   #step-controls .play::before { content: "Play"; }
 }
 
+button, textarea { border: none; }
 #step-controls button:hover { cursor: pointer; }
-#step-controls button:hover, textarea:focus { border: 2px solid blue; }
-#step-controls button, textarea { border: 2px solid steelblue; background: transparent; }
+#step-controls button, textarea { background: darkslateblue; color: white; }
+#step-controls button:hover, textarea:focus { background: slateblue; }
 #step-controls button:disabled, textarea:disabled {
-    background: #cdecfa; border-color: #cdecfa; cursor: default; }
+    background: transparent; color: mediumpurple; cursor: default; }
 
 #input-controls button { float: right; }

--- a/www/widgets/widget.css
+++ b/www/widgets/widget.css
@@ -1,19 +1,14 @@
-html, body, figure { margin: 0; padding: 0; height: 100%; }
-figure { width: 100%; }
+html, body, #widget, fieldset { border: none; margin: 0; padding: 0; }
+#widget, #controls { width: 100%; }
 #controls {
-    box-sizing: border-box; margin: 0; padding: .5em .5em 0;
-    background: #e5f7ff; border-top: 2px solid steelblue;
+    box-sizing: border-box; margin: 0; padding: .5em;
+    background: #e5f7ff; border-bottom: 2px solid steelblue; font-size: 20px;
 }
-fieldset { border: none; margin: 0; padding: 0; }
-#input-controls { margin: .5em 0; }
 
-#controls {
-    position: absolute; width: 100%; bottom: 0; overflow: hidden;
-    font-size: 20px;
-}
+#input-controls { margin: .5em 0 0; overflow: hidden; }
 @media (max-height: 400px) {
   #input-controls { transition: all .3s ease; max-height: 160px; }
-  .running #input-controls { max-height: 0; margin: .5em 0 0; }
+  .running #input-controls { max-height: 0; margin: 0; }
 }
 
 #step-controls { display: flex; gap: 1ex; }
@@ -24,10 +19,12 @@ fieldset { border: none; margin: 0; padding: 0; }
 #step-controls .left { order: 1; }
 #step-controls .right { order: 5; }
 #step-controls button { font: 70% sans-serif; min-width: 2em; height: 2em; border-radius: 1em; }
-#input-controls textarea { box-sizing: border-box; width: 100%; font: 100% monospace; }
+#input-controls textarea {
+    box-sizing: border-box; display: block; width: 100%; font: 1em monospace; margin: 0;
+}
 @media (max-width: 600px) { #controls { font-size: 16px; } }
-@media (max-width: 400px) {
-  #controls { padding: .5ex .5ex 0; font-size: 14px; }
+@media (max-width: 450px) {
+  #controls { padding: .5ex; font-size: 14px; }
   #input-controls { margin: .5ex 0; }
   .running #input-controls { margin: .5ex 0 0; }
   #step-controls { gap: .5ex; }

--- a/www/widgets/widget.css
+++ b/www/widgets/widget.css
@@ -7,24 +7,38 @@ figure { width: 100%; }
 fieldset { border: none; margin: 0; padding: 0; }
 #input-controls { margin: .5em 0; }
 
-#controls { position: absolute; left: 0; right: 0; bottom: 0; overflow: hidden; }
+#controls {
+    position: absolute; width: 100%; bottom: 0; overflow: hidden;
+    font-size: 20px;
+}
 @media (max-height: 400px) {
   #input-controls { transition: all .3s ease; max-height: 160px; }
   .running #input-controls { max-height: 0; margin: .5em 0 0; }
 }
 
-#step-controls { display: flex; gap: 1ex; font-size: 20px; }
+#step-controls { display: flex; gap: 1ex; }
 #step-controls h1 {
     flex-grow: 1; order: 3; text-align: center;
     font: 100% sans; margin: 0; line-height: 1.33em;
 }
 #step-controls .left { order: 1; }
 #step-controls .right { order: 5; }
-@media (max-width: 600px) { #step-controls { font-size: 16px; } }
-@media (max-width: 400px) { #step-controls { flex-wrap: wrap; } }
 #step-controls button { font: 70% sans-serif; min-width: 2em; height: 2em; border-radius: 1em; }
-
-textarea { box-sizing: border-box; width: 100%; font: 20px monospace; }
+#input-controls textarea { box-sizing: border-box; width: 100%; font: 100% monospace; }
+@media (max-width: 600px) { #controls { font-size: 16px; } }
+@media (max-width: 400px) {
+  #controls { padding: .5ex .5ex 0; font-size: 14px; }
+  #input-controls { margin: .5ex 0; }
+  .running #input-controls { margin: .5ex 0 0; }
+  #step-controls { gap: .5ex; }
+  #step-controls button { min-width: 0; padding: 2px; }
+  #step-controls button.play { width: auto; }
+  #step-controls button span { font-size: 0px; }
+  #step-controls .reset::before { content: "Reset"; }
+  #step-controls .stepb::before { content: "◀"; }
+  #step-controls .stepf::before { content: "▶"; }
+  #step-controls .play::before { content: "Play"; }
+}
 
 #step-controls button:hover { cursor: pointer; }
 #step-controls button:hover, textarea:focus { border: 2px solid blue; }


### PR DESCRIPTION
This PR restyles the widgets to have navy-blue controls on top instead of baby-blue controls below. The style is visually simpler, has less CSS magic, and works better on mobile. This PR also redoes some details in the baselines widget (our currently most complex widget) to work better on mobile as well.