### PR TITLE
Remove early out when editing mode is on

### DIFF
--- a/www/feedback.js
+++ b/www/feedback.js
@@ -3,8 +3,6 @@
 // Thanks for reading the code! You can hit Ctrl+E to access the feedback tools.
 
 document.addEventListener("DOMContentLoaded", function() {
-    if (window.localStorage["edit"] == "true") return typo_mode();
-
     window.addEventListener("keydown", function(e) {
         if (String.fromCharCode(e.keyCode) != "E") return;
         if (!(e.metaKey || e.ctrlKey)) return;

--- a/www/feedback.js
+++ b/www/feedback.js
@@ -222,6 +222,7 @@ function setup_feedback() {
     }
     
     function do_cancel(e) {
+        window.localStorage["edit"] = "false";
         overlay.remove();
     }
 


### PR DESCRIPTION
Otherwise, there appears to be no way for the user to get out of edit mode, and will be stuck in it forever.

Also, change localstorage state back to false when canceling.