### PR TITLE
Add RSS to the feedback tool

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,6 +43,9 @@ wc:
 publish:
 	rsync -rtu --exclude=*.pickle --exclude=*.hash www/ server:/home/www/browseng/
 	ssh server chmod -Rf a+r /home/www/browseng/ || true
+
+restart:
+	rsync infra/api.py server:/home/www/browseng/
 	ssh server sudo systemctl restart browser-engineering.service
 
 download:

--- a/infra/api.py
+++ b/infra/api.py
@@ -163,6 +163,12 @@ def feedback():
             saved.setdefault(page, []).append(prettify(o))
     return { 'new': new, 'saved': saved }
 
+@bottle.route("/feedback.rss")
+@bottle.view("feedback_rss.view")
+def feedback():
+    new = [prettify(o) for o in DATA if o['status'] == "new"]
+    return { 'new': new }
+
 @bottle.route("/api/status", method=["POST", "OPTIONS"])
 def status():
     data = json.load(bottle.request.body)

--- a/www/feedback_rss.view
+++ b/www/feedback_rss.view
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="utf-8"?>
+% from datetime import datetime
+<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
+<channel>
+
+<title>Feedback on Web Browser Engineering</title>
+<atom:link href="https://browser.engineering/feedback.rss" rel="self" type="application/rss+xml" />
+<link>https://browser.engineering/feedback.rss</link>
+<description>Unprocessed user feedback on Web Browser Engineering</description>
+<language>en</language>
+<lastBuildDate>{{datetime.now().strftime("%a, %d %b %Y %H:%M:%S %z")}}</lastBuildDate>
+<webMaster>author@browser.engineering (Pavel Panchekha & Chris Harrelson)</webMaster>
+  
+%for obj in new:
+<item>
+  %if obj['status'] == 'new':
+    <title> in <code>{{obj['url']}}</code>:</title>
+    <link>https://browser.engineering/feedback</link>
+    %if 'name' in obj:
+    <author>{{obj['name']}}</author>
+    %end
+    %if 'time' in obj:
+    <pubDate>{{datetime.fromtimestamp(obj['time'].strftime("%a, %d %b %Y %H:%M:%S %z"))}}</pubDate>
+    %end
+
+    <description>
+    %if obj['type'] == 'typo':
+      <blockquote>{{!obj['diff']}}</blockquote>
+    %elif obj['type'] == 'comment':
+      <blockquote>{{obj['text']}}</blockquote>
+      <p>{{obj['comment']}}</p>
+    %else:
+      <p>Overall comment:</p>
+      <p>{{obj['comment']}}</p>
+    %end
+    </description>
+  %end
+</item>
+%end
+</channel>
+</rss>


### PR DESCRIPTION
This PR adds the `/feedback.rss` endpoint to Web Browser Engineering. to get easy notifications for new feedback. I've subscribed to it in my feed reader, and it will (I hope) list new feedback submitted by users in a reasonably timely fashion.